### PR TITLE
fix: delete an existing peer

### DIFF
--- a/src/wireguard_tools/wireguard_netlink.py
+++ b/src/wireguard_tools/wireguard_netlink.py
@@ -82,7 +82,7 @@ class WireguardNetlinkDevice(WireguardDevice):
 
         # remove peers that are no longer in the configuration
         for key in cur_peers.difference(new_peers):
-            self.wg.set(self.interface, peer=dict(public_key=key, remove=True))
+            self.wg.set(self.interface, peer=dict(public_key=str(key), remove=True))
 
         # update any changed peers
         for key in cur_peers.intersection(new_peers):


### PR DESCRIPTION
This pull request aims to fix the deletion of a peer in the existing configuration.

During `set_config` on a device, the object to be provided being a `WireguardConfig`, the list of peers contains `WireguardKey` type objects for the private key.

If we provide as is, we get the error: _Failed to decode Base64 key_
because it is not possible to decode in base 64 this object.

We can see it for the following cases, the `_wg_set_peer_arg` method does indeed cast the `WireguardKey` object to a string, this seems to be an oversight for the deletion part