### PR TITLE
Allow import WireguardPeer

### DIFF
--- a/src/wireguard_tools/__init__.py
+++ b/src/wireguard_tools/__init__.py
@@ -7,8 +7,8 @@
 
 __version__ = "0.4.4.post.dev0"
 
-from .wireguard_config import WireguardConfig
+from .wireguard_config import WireguardConfig, WireguardPeer
 from .wireguard_device import WireguardDevice
 from .wireguard_key import WireguardKey
 
-__all__ = ["WireguardConfig", "WireguardDevice", "WireguardKey"]
+__all__ = ["WireguardConfig", "WireguardPeer", "WireguardDevice", "WireguardKey"]

--- a/src/wireguard_tools/__init__.py
+++ b/src/wireguard_tools/__init__.py
@@ -11,4 +11,4 @@ from .wireguard_config import WireguardConfig, WireguardPeer
 from .wireguard_device import WireguardDevice
 from .wireguard_key import WireguardKey
 
-__all__ = ["WireguardConfig", "WireguardPeer", "WireguardDevice", "WireguardKey"]
+__all__ = ["WireguardConfig", "WireguardDevice", "WireguardKey", "WireguardPeer"]


### PR DESCRIPTION
Add WireguardPeer class in `__all__ = [] ` public object list.