### PR TITLE
Make spaces after commas optional

### DIFF
--- a/src/wireguard_tools/wireguard_config.py
+++ b/src/wireguard_tools/wireguard_config.py
@@ -123,7 +123,7 @@ class WireguardPeer:
                 conf["persistent_keepalive"] = int(value)
             elif key == "allowedips":
                 conf.setdefault("allowed_ips", []).extend(
-                    ip_interface(addr) for addr in value.split(", ")
+                    ip_interface(addr.strip()) for addr in value.split(",")
                 )
             elif key == "# friendly_name":
                 conf["friendly_name"] = value
@@ -250,16 +250,16 @@ class WireguardConfig:
             elif key == "listenport":
                 self.listen_port = int(value)
             elif key == "address":
-                self.addresses.extend(ip_interface(addr) for addr in value.split(", "))
+                self.addresses.extend(ip_interface(addr.strip()) for addr in value.split(","))
             elif key == "dns":
-                for item in value.split(", "):
-                    self._add_dns_entry(item)
+                for item in value.split(","):
+                    self._add_dns_entry(item.strip())
             elif key == "mtu":
                 self.mtu = int(value)
             elif key == "includedapplications":
-                self.included_applications.extend(item for item in value.split(", "))
+                self.included_applications.extend(item.strip() for item in value.split(","))
             elif key == "excludedapplications":
-                self.excluded_applications.extend(item for item in value.split(", "))
+                self.excluded_applications.extend(item.strip() for item in value.split(","))
             elif key == "preup":
                 self.preup.append(value)
             elif key == "postup":


### PR DESCRIPTION
In Wireguard configs the addresses may be listed with or without spaces after commas (e.g., "10.0.0.1/24, 10.0.0.2/24" or "10.0.0.1/24,10.0.0.2/24"). Therefore, using split(",") and strip() is appropriate and ensures all formats are handled.

Fixes #14 