### PR TITLE
Fixed file descriptors leaking

### DIFF
--- a/src/wireguard_tools/wireguard_netlink.py
+++ b/src/wireguard_tools/wireguard_netlink.py
@@ -21,6 +21,9 @@ class WireguardNetlinkDevice(WireguardDevice):
         super().__init__(interface)
         self.wg = pyroute2.WireGuard()
 
+    def close(self) -> None:
+        self.wg.close()
+
     def get_config(self) -> WireguardConfig:
         try:
             attrs = dict(self.wg.info(self.interface)[0]["attrs"])


### PR DESCRIPTION
This pull request fix file descriptors leaking

Reproduce:

```
: python3
>> from wireguard_tools.wireguard_device import WireguardDevice
>> import os
>> os.getpid()
2752726

# open /proc/2752726/fd in another terminal
# [root@DEV017 fd]# ls -lah
# total 0
# dr-x------ 2 root root  0 Sep  4 17:27 .
# dr-xr-xr-x 9 root root  0 Sep  4 17:26 ..
# lrwx------ 1 root root 64 Sep  4 17:27 0 -> /dev/pts/3
# lrwx------ 1 root root 64 Sep  4 17:27 1 -> /dev/pts/3
# lrwx------ 1 root root 64 Sep  4 17:27 2 -> /dev/pts/3

# get device
>> device = WireguardDevice.get(INTERFACE_NAME)

# check descriptors
# [root@DEV017 fd]# ls -lah
# total 0
# dr-x------ 2 root root  0 Sep  4 17:27 .
# dr-xr-xr-x 9 root root  0 Sep  4 17:26 ..
# lrwx------ 1 root root 64 Sep  4 17:27 0 -> /dev/pts/3
# lrwx------ 1 root root 64 Sep  4 17:27 1 -> /dev/pts/3
# lrwx------ 1 root root 64 Sep  4 17:27 2 -> /dev/pts/3
# lr-x------ 1 root root 64 Sep  4 17:27 3 -> 'pipe:[9026165]'
# l-wx------ 1 root root 64 Sep  4 17:27 4 -> 'pipe:[9026165]'
# lrwx------ 1 root root 64 Sep  4 17:27 5 -> 'socket:[9026166]'

#  new descriptors 3, 4, 5
# now we close device

>> device.close()
# check descriptors again and see 3, 4, 5 again...
# [root@DEV017 fd]# ls -lah
# total 0
# dr-x------ 2 root root  0 Sep  4 17:27 .
# dr-xr-xr-x 9 root root  0 Sep  4 17:26 ..
# lrwx------ 1 root root 64 Sep  4 17:27 0 -> /dev/pts/3
# lrwx------ 1 root root 64 Sep  4 17:27 1 -> /dev/pts/3
# lrwx------ 1 root root 64 Sep  4 17:27 2 -> /dev/pts/3
# lr-x------ 1 root root 64 Sep  4 17:27 3 -> 'pipe:[9026165]'
# l-wx------ 1 root root 64 Sep  4 17:27 4 -> 'pipe:[9026165]'
# lrwx------ 1 root root 64 Sep  4 17:27 5 -> 'socket:[9026166]'

# now we close pyroute2.WireGuard object
>> device.wg.close()

# and here we now, 3, 4, 5 descriptors were closed
# [root@DEV017 fd]# ls -lah
# total 0
# dr-x------ 2 root root  0 Sep  4 17:27 .
# dr-xr-xr-x 9 root root  0 Sep  4 17:26 ..
# lrwx------ 1 root root 64 Sep  4 17:27 0 -> /dev/pts/3
# lrwx------ 1 root root 64 Sep  4 17:27 1 -> /dev/pts/3
# lrwx------ 1 root root 64 Sep  4 17:27 2 -> /dev/pts/3
```