### PR TITLE
Split config sections based on entire line

### DIFF
--- a/src/wireguard_tools/wireguard_config.py
+++ b/src/wireguard_tools/wireguard_config.py
@@ -221,7 +221,7 @@ class WireguardConfig:
     @classmethod
     def from_wgconfig(cls, configfile: TextIO) -> WireguardConfig:
         text = configfile.read()
-        _pre, *parts = re.split(r"\[(Interface|Peer)\]\n", text, flags=re.I)
+        _pre, *parts = re.split(r"^\[(Interface|Peer)\]$", text, flags=re.I | re.M)
         sections = [section.lower() for section in parts[0::2]]
         if sections.count("interface") > 1:
             msg = "More than one [Interface] section in config file"


### PR DESCRIPTION
Currently you'll get the following error if parsing a config file with a commented out peer:

```
Traceback (most recent call last):
  File "<python-input-1>", line 2, in <module>
    config = WireguardConfig.from_wgconfig(fh)
  File "/usr/local/lib/python3.13/site-packages/wireguard_tools/wireguard_config.py", line 239, in from_wgconfig
    peer = WireguardPeer.from_wgconfig(key_value)
  File "/usr/local/lib/python3.13/site-packages/wireguard_tools/wireguard_config.py", line 132, in from_wgconfig
    return cls(**conf)
TypeError: WireguardPeer.__init__() missing 1 required positional argument: 'public_key'
```

This PR fixes it by only matching full lines for section headings.