### PR TITLE
Fixed getting all peers from netlink response

### DIFF
--- a/src/wireguard_tools/wireguard_netlink.py
+++ b/src/wireguard_tools/wireguard_netlink.py
@@ -26,7 +26,8 @@ class WireguardNetlinkDevice(WireguardDevice):
 
     def get_config(self) -> WireguardConfig:
         try:
-            attrs = dict(self.wg.info(self.interface)[0]["attrs"])
+            info = self.wg.info(self.interface)
+            attrs = dict(info[0]["attrs"])
         except pyroute2.netlink.exceptions.NetlinkError as exc:
             msg = f"Unable to access interface: {exc.args[1]}"
             raise RuntimeError(msg) from exc
@@ -43,7 +44,9 @@ class WireguardNetlinkDevice(WireguardDevice):
         )
 
         for peer_attrs in (
-            dict(peer["attrs"]) for peer in attrs.get("WGDEVICE_A_PEERS", [])
+            dict(peer["attrs"])
+            for part in info
+            for peer in part.get("WGDEVICE_A_PEERS", [])
         ):
             peer = WireguardPeer(
                 public_key=peer_attrs["WGPEER_A_PUBLIC_KEY"].decode("utf-8"),


### PR DESCRIPTION
According to the [issue](https://github.com/svinota/pyroute2/issues/1212) and the related [comment](https://github.com/svinota/pyroute2/issues/1212#issuecomment-2436202613), it is necessary to add support for processing multiple netlink responses in order to retrieve all peers.