### PR TITLE
feat: Enhanced UAPI, full CLI, wg-quick in pure Python, and wg-daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,56 +2,79 @@
 
 Pure Python reimplementation of wireguard-tools with an aim to provide easily
 reusable library functions to handle reading and writing of
-[WireGuard®](https://www.wireguard.com/) configuration files as well as
+[WireGuard](https://www.wireguard.com/) configuration files as well as
 interacting with WireGuard devices, both in-kernel through the Netlink API and
 userspace implementations through the cross-platform UAPI API.
 
+This fork extends the upstream
+[cmusatyalab/wireguard-tools](https://github.com/cmusatyalab/wireguard-tools)
+with a complete CLI, a pure-Python `wg-quick` implementation, and a privileged
+daemon for IPC-based privilege separation.
 
-## Installation/Usage
-
-```sh
-    pipx install wireguard-tools
-    wg-py --help
-```
-
-Implemented `wg` command line functionality,
-
-- [x] show - Show configuration and device information
-- [x] showconf - Dump current device configuration
-- [ ] set - Change current configuration, add/remove/change peers
-- [x] setconf - Apply configuration to device
-- [ ] addconf - Append configuration to device
-- [x] syncconf - Synchronizes configuration with device
-- [x] genkey, genpsk, pubkey - Key generation
-
-
-Also includes some `wg-quick` functions,
-
-- [ ] up, down - Create and configure WireGuard device and interface
-- [ ] save - Dump device and interface configuration
-- [x] strip - Filter wg-quick settings from configuration
-
-
-Needs root (sudo) access to query and configure the WireGuard devices through
-netlink. But root doesn't know about the currently active virtualenv, you may
-have to pass the full path to the script in the virtualenv, or use
-`python3 -m wireguard_tools`
+## Installation
 
 ```sh
-    sudo `which wg-py` showconf <interface>
-    sudo /path/to/venv/python3 -m wireguard_tools showconf <interface>
+pip install wireguard-tools
+wg-py --help
 ```
 
+For the latest development version:
 
-## Library usage
+```sh
+pip install git+https://github.com/radawson/wireguard-tools.git@dev
+```
+
+## CLI Commands
+
+### `wg-py` -- WireGuard configuration tool
+
+Implemented `wg` command-line functionality:
+
+- [x] show -- Show configuration and device information (dump, field filtering, `WG_HIDE_KEYS`)
+- [x] showconf -- Dump current device configuration
+- [x] set -- Change current configuration, add/remove/change peers
+- [x] setconf -- Apply configuration to device (atomic replace)
+- [x] addconf -- Append configuration to device
+- [x] syncconf -- Synchronize configuration with device (diff and apply)
+- [x] genkey, genpsk, pubkey -- Key generation
+
+Also includes `wg-quick` functions:
+
+- [x] up, down -- Create and configure WireGuard device and interface
+- [x] save -- Dump device and interface configuration
+- [x] strip -- Filter wg-quick settings from configuration
+
+Needs root (sudo) access to query and configure WireGuard devices through
+netlink. But root doesn't know about the currently active virtualenv, so you
+may have to pass the full path to the script, or use `python3 -m wireguard_tools`:
+
+```sh
+sudo $(which wg-py) showconf <interface>
+sudo /path/to/venv/python3 -m wireguard_tools showconf <interface>
+```
+
+### `wg-daemon` -- Privileged helper daemon
+
+A JSON-over-Unix-socket daemon that runs as root and exposes WireGuard
+operations to unprivileged clients. This enables privilege separation: your
+application connects to the daemon socket instead of requiring root access
+itself.
+
+```sh
+sudo wg-daemon --socket /var/run/wg-daemon.sock --group wireguard
+```
+
+See [docs/DAEMON.md](docs/DAEMON.md) for protocol details, systemd setup, and
+security model.
+
+## Library Usage
 
 ### Parsing WireGuard keys
 
-The WireguardKey class will parse base64-encoded keys, the default base64
-encoded string, but also an urlsafe base64 encoded variant. It also exposes
-both private key generating and public key deriving functions. Be sure to pass
-any base64 or hex encoded keys as 'str' and not 'bytes', otherwise it will
-assume the key was already decoded to its raw form.
+The `WireguardKey` class parses base64-encoded keys (standard and urlsafe
+variants) and hex-encoded keys. It also exposes private key generation and
+public key derivation. Pass any base64 or hex encoded keys as `str`, not
+`bytes` -- a `bytes` value is assumed to be the already-decoded raw key.
 
 ```python
 from wireguard_tools import WireguardKey
@@ -59,23 +82,16 @@ from wireguard_tools import WireguardKey
 private_key = WireguardKey.generate()
 public_key = private_key.public_key()
 
-# print base64 encoded key
-print(public_key)
-
-# print urlsafe encoded key
-print(public_key.urlsafe)
-
-# print hexadecimal encoded key
-print(public_key.hex())
+print(public_key)          # base64
+print(public_key.urlsafe)  # urlsafe base64
+print(public_key.hex())    # hexadecimal
 ```
 
-### Working with WireGuard configuration files
+### Working with configuration files
 
-The WireGuard configuration file is similar to, but not quite, the INI format
-because it has duplicate keys for both section names (i.e. [Peer]) as well as
-configuration keys within a section. According to the format description,
-AllowedIPs, Address, and DNS configuration keys 'may be specified multiple
-times'.
+The WireGuard configuration file format uses duplicate keys for both section
+names (`[Peer]`) and configuration keys within a section. `AllowedIPs`,
+`Address`, and `DNS` may be specified multiple times.
 
 ```python
 from wireguard_tools import WireguardConfig
@@ -84,79 +100,47 @@ with open("wg0.conf") as fh:
     config = WireguardConfig.from_wgconfig(fh)
 ```
 
-Also supported are the "Friendly Tags" comments as introduced by
-prometheus-wireguard-exporter, where a `[Peer]` section can contain
-comments which add a user friendly description and/or additional attributes.
+"Friendly Tags" comments (as introduced by prometheus-wireguard-exporter) are
+supported:
 
-```
+```ini
 [Peer]
 # friendly_name = Peer description for end users
-# friendly_json = {"flat"="json", "dictionary"=1, "attribute"=2}
-...
+# friendly_json = {"flat": "json", "dictionary": 1, "attribute": 2}
 ```
 
-These will show up as additional `friendly_name` and `friendly_json` attributes
-on the WireguardPeer object.
+These appear as `friendly_name` and `friendly_json` attributes on the
+`WireguardPeer` object.
 
-We can also serialize and deserialize from a simple dict-based format which
-uses only basic JSON datatypes and, as such, can be used to convert to various
-formats (i.e. json, yaml, toml, pickle) either to disk or to pass over a
-network.
+Serialize and deserialize from a dict-based format using only basic JSON types:
 
 ```python
 from wireguard_tools import WireguardConfig
-from pprint import pprint
 
 dict_config = dict(
     private_key="...",
     peers=[
         dict(
             public_key="...",
-            preshared_key=None,
             endpoint_host="remote_host",
-            endpoint_port=5120,
-            persistent_keepalive=30,
-            allowed_ips=["0.0.0.0/0"],
-            friendly_name="Awesome Peer",
+            endpoint_port=51820,
+            persistent_keepalive=25,
+            allowed_ips=["10.0.0.0/24"],
+            friendly_name="My Peer",
         ),
     ],
 )
 config = WireguardConfig.from_dict(dict_config)
-
-dict_config = config.asdict()
-pprint(dict_config)
+roundtrip = config.asdict()
 ```
 
-Finally, there is a `to_qrcode` function that returns a segno.QRCode object
-which contains the configuration. This can be printed and scanned with the
-wireguard-android application. Careful with these because the QRcode exposes
-an easily captured copy of the private key as part of the configuration file.
-It is convenient, but definitely not secure.
+Generate a QR code scannable by the WireGuard mobile app:
 
 ```python
-from wireguard_tools import WireguardConfig
-from pprint import pprint
-
-dict_config = dict(
-    private_key="...",
-    peers=[
-        dict(
-            public_key="...",
-            preshared_key=None,
-            endpoint_host="remote_host",
-            endpoint_port=5120,
-            persistent_keepalive=30,
-            allowed_ips=["0.0.0.0/0"],
-        ),
-    ],
-)
-config = WireguardConfig.from_dict(dict_config)
-
 qr = config.to_qrcode()
 qr.save("wgconfig.png")
 qr.terminal(compact=True)
 ```
-
 
 ### Working with WireGuard devices
 
@@ -166,51 +150,97 @@ from wireguard_tools import WireguardDevice
 ifnames = [device.interface for device in WireguardDevice.list()]
 
 device = WireguardDevice.get("wg0")
+config = device.get_config()
 
-wgconfig = device.get_config()
-
-device.set_config(wgconfig)
+device.set_config(config)   # atomic replace (setconf semantics)
+device.sync_config(config)  # diff and apply changes only (syncconf semantics)
 ```
 
-## Bugs
+`WireguardDevice.get()` tries the UAPI backend first (userspace socket in
+`/var/run/wireguard/`), then falls back to the Netlink backend (in-kernel).
 
-The setconf/syncconf implementation is not quite correct. They currently use
-the same underlying set of operations but netlink-api's `set_config`
-implementation actually does something closer to syncconf, while the uapi-api
-implementation matches setconf.
+### Using wg-quick from Python
 
-This implementation has only been tested on Linux where we've only actively
-used a subset of the available functionality, i.e. the common scenario is
-configuring an interface only once with just a single peer.
+Bring interfaces up and down programmatically. Requires root or `CAP_NET_ADMIN`.
 
+```python
+from wireguard_tools.wg_quick import up, down
+
+up("wg0")    # equivalent to: wg-quick up wg0
+down("wg0")  # equivalent to: wg-quick down wg0
+```
+
+The implementation uses `pyroute2` for netlink-based interface, address, and
+route management -- no shell commands are spawned for network operations.
+
+### Using the daemon client
+
+Connect to a running `wg-daemon` instance from an unprivileged process:
+
+```python
+from wireguard_tools.daemon_client import WgDaemonClient
+
+client = WgDaemonClient()  # or WgDaemonClient("/var/run/wg-daemon.sock")
+
+client.up("wg0")
+client.down("wg0")
+
+config = client.show("wg0")
+
+client.set_peer("wg0", "base64pubkey...", allowed_ips=["10.0.0.2/32"])
+client.remove_peer("wg0", "base64pubkey...")
+
+interfaces = client.list_devices()
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `WG_ENDPOINT_RESOLUTION_RETRIES` | `15` | Max DNS resolution retries for peer endpoints (`infinity` for unlimited) |
+| `WG_HIDE_KEYS` | unset | When set to `never`, `wg show` displays private and preshared keys |
+| `WG_DAEMON_SOCKET` | `/var/run/wg-daemon.sock` | Unix socket path for daemon/client |
+| `WG_DAEMON_GROUP` | `wireguard` | Group ownership for the daemon socket |
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md) -- Module map, layer diagram, backend selection
+- [Daemon](docs/DAEMON.md) -- Protocol spec, systemd setup, security model
+- [Integration Guide](docs/INTEGRATION.md) -- Developer guide with API reference
+- [Changelog](docs/CHANGELOG.md) -- Version history
 
 ## Licenses
 
 wireguard-tools is MIT licensed
 
-    Copyright (c) 2022-2024 Carnegie Mellon University
+```text
+Copyright (c) 2022-2024 Carnegie Mellon University
+Copyright (c) 2024-2026 Richard Dawson
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy of
-    this software and associated documentation files (the "Software"), to deal in
-    the Software without restriction, including without limitation the rights to
-    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-    of the Software, and to permit persons to whom the Software is furnished to do
-    so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
 
 `wireguard_tools/curve25519.py` was released in the public domain
 
-    Copyright Nicko van Someren, 2021. This code is released into the public domain.
-    https://gist.github.com/nickovs/cc3c22d15f239a2640c185035c06f8a3
+```text
+Copyright Nicko van Someren, 2021. This code is released into the public domain.
+https://gist.github.com/nickovs/cc3c22d15f239a2640c185035c06f8a3
+```
 
 "WireGuard" is a registered trademark of Jason A. Donenfeld.

--- a/contrib/wg-daemon.service
+++ b/contrib/wg-daemon.service
@@ -1,0 +1,33 @@
+# systemd service for the WireGuard Tools Daemon
+#
+# Install:
+#   1. Copy this file to /etc/systemd/system/wg-daemon.service
+#   2. Adjust ExecStart to point at the venv where wireguard-tools is installed
+#   3. Create the 'wireguard' group:  sudo groupadd wireguard
+#   4. Add the GUI user to the group: sudo usermod -aG wireguard <gui-user>
+#   5. sudo systemctl daemon-reload && sudo systemctl enable --now wg-daemon
+#
+[Unit]
+Description=WireGuard Tools Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/wg-daemon
+Restart=on-failure
+RestartSec=3
+
+User=root
+Group=wireguard
+
+RuntimeDirectory=wg-daemon
+RuntimeDirectoryMode=0755
+
+# Harden
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+NoNewPrivileges=no
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,125 @@
+# Architecture
+
+## Module Map
+
+| Module | Purpose |
+| --- | --- |
+| `wireguard_key.py` | Key parsing (base64, hex, urlsafe), generation, and public key derivation |
+| `curve25519.py` | Pure-Python Curve25519 scalar multiplication (no C dependencies) |
+| `wireguard_config.py` | `WireguardConfig` and `WireguardPeer` data classes; parsing and serialization of `.conf` files and dict roundtrips |
+| `wireguard_device.py` | `WireguardDevice` abstract base class with backend discovery (`get()` and `list()`) |
+| `wireguard_uapi.py` | UAPI backend -- communicates with userspace WireGuard via `/var/run/wireguard/<ifname>.sock` |
+| `wireguard_netlink.py` | Netlink backend -- communicates with in-kernel WireGuard via `pyroute2` |
+| `wg_quick.py` | Pure-Python `wg-quick up/down` using `pyroute2` for interface, address, route, and rule management |
+| `cli.py` | `wg-py` command-line interface implementing all `wg(8)` subcommands plus `up`/`down` |
+| `daemon.py` | `wg-daemon` -- threaded Unix socket server dispatching JSON commands to library functions |
+| `daemon_client.py` | `WgDaemonClient` -- thin IPC client for connecting to `wg-daemon` |
+| `__init__.py` | Public API surface: re-exports `WireguardConfig`, `WireguardPeer`, `WireguardDevice`, `WireguardKey` |
+
+## Layer Diagram
+
+```mermaid
+flowchart TB
+    subgraph consumers [Consumers]
+        CLI["cli.py\nwg-py command"]
+        Daemon["daemon.py\nwg-daemon"]
+        DaemonClient["daemon_client.py\nWgDaemonClient"]
+        WgQuick["wg_quick.py\nup / down"]
+    end
+
+    subgraph core [Core Library]
+        Config["wireguard_config.py\nWireguardConfig / WireguardPeer"]
+        Device["wireguard_device.py\nWireguardDevice ABC"]
+        Key["wireguard_key.py\nWireguardKey"]
+        Curve["curve25519.py\nX25519"]
+    end
+
+    subgraph backends [Device Backends]
+        UAPI["wireguard_uapi.py\nWireguardUAPIDevice"]
+        Netlink["wireguard_netlink.py\nWireguardNetlinkDevice"]
+    end
+
+    subgraph external [External]
+        KernelWG["Kernel WireGuard\nvia Netlink"]
+        UserWG["Userspace WireGuard\nvia /var/run/wireguard/"]
+        Pyroute["pyroute2\nNetlink library"]
+    end
+
+    CLI --> Config
+    CLI --> Device
+    CLI --> WgQuick
+    Daemon --> WgQuick
+    Daemon --> Device
+    DaemonClient -->|"JSON over Unix socket"| Daemon
+
+    WgQuick --> Config
+    WgQuick --> Device
+    WgQuick --> Pyroute
+
+    Device --> UAPI
+    Device --> Netlink
+    Key --> Curve
+
+    Config --> Key
+    UAPI --> UserWG
+    Netlink --> Pyroute
+    Pyroute --> KernelWG
+```
+
+## Backend Selection
+
+`WireguardDevice.get(ifname)` selects the backend automatically:
+
+1. **UAPI first**: Checks for `/var/run/wireguard/<ifname>.sock`. If the socket exists, returns a `WireguardUAPIDevice`. This handles userspace WireGuard implementations (e.g., wireguard-go, boringtun).
+2. **Netlink fallback**: If no UAPI socket is found, returns a `WireguardNetlinkDevice` which talks directly to the in-kernel WireGuard module via `pyroute2`.
+
+`WireguardDevice.list()` yields devices from both backends, querying Netlink first and then scanning the UAPI socket directory.
+
+## setconf vs syncconf
+
+Both backends now implement distinct behaviors:
+
+- **`set_config()`** (setconf semantics): Atomically replaces the full interface configuration. Sends `replace_peers=true` in UAPI; in Netlink, diffs against current state but applies all peers.
+- **`sync_config()`** (syncconf semantics): Diffs the desired config against the running config and applies only changes -- removes absent peers, skips unchanged ones, updates modified ones.
+
+## Data Flow: `wg-quick up wg0`
+
+1. `_find_config("wg0")` resolves to `/etc/wireguard/wg0.conf`
+2. Config file is parsed into a `WireguardConfig` object
+3. PreUp hooks execute (shell commands with `WIREGUARD_INTERFACE` env var)
+4. `pyroute2` creates the `wg0` interface (`ip link add wg0 type wireguard`)
+5. `WireguardDevice.get("wg0")` opens the appropriate backend
+6. `device.set_config(config)` applies keys, peers, and endpoints via UAPI/Netlink
+7. Addresses are assigned via `pyroute2` (`ip addr add`)
+8. Link is brought up with MTU (`ip link set wg0 up mtu 1420`)
+9. Routes are added for each peer's AllowedIPs
+10. If catch-all AllowedIPs (`0.0.0.0/0` or `::/0`) are present with `Table = auto`, fwmark rules and suppress-prefix rules are installed
+11. DNS is configured via `resolvconf` if DNS servers are specified
+12. PostUp hooks execute
+
+If any step after interface creation fails, the interface is deleted to avoid leaving a half-configured device.
+
+## Data Flow: Daemon IPC
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Client as WgDaemonClient
+    participant Socket as Unix Socket
+    participant Daemon as wg-daemon
+    participant WG as WireGuard
+
+    App->>Client: client.up("wg0")
+    Client->>Socket: connect()
+    Client->>Socket: {"cmd":"up","args":{"interface":"wg0"}}
+    Socket->>Daemon: read request
+    Daemon->>WG: wg_quick.up("wg0")
+    WG-->>Daemon: success
+    Daemon->>Socket: {"ok":true}
+    Socket-->>Client: read response
+    Client-->>App: return
+```
+
+The daemon handles one request per connection. The client connects, sends a
+single JSON line, shuts down the write side, reads the response, and
+disconnects. This stateless design avoids connection management complexity.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,92 @@
+# Changelog
+
+## v0.7.0.dev0 (2026-03-14)
+
+This release significantly extends the upstream library with a complete CLI,
+pure-Python `wg-quick`, and a privileged daemon for IPC-based privilege
+separation. All changes are backward-compatible with the v0.6.0 public API.
+
+### Core library fixes
+
+- **IPv6 endpoint parsing**: New `_parse_endpoint()` function correctly handles
+  bracket notation (`[::1]:51820`) throughout config parsing, UAPI
+  serialization, and wgconfig output.
+- **Robust comma-list parsing**: `_split_comma_list()` filters empty entries
+  from inputs like `"10.0.0.0/24,"` or `"a,,b"` that previously raised
+  `ValueError` in downstream parsers.
+- **Hex FwMark support**: FwMark values now accept both hexadecimal (`0x1234`)
+  and decimal formats via `int(value, 0)`.
+- **Case-insensitive SaveConfig**: Parsing now uses `value.lower() == "true"`
+  instead of an exact match.
+
+### UAPI backend (`wireguard_uapi.py`)
+
+- Hostname resolution with `WG_ENDPOINT_RESOLUTION_RETRIES` support, matching
+  the behavior of the C `wg(8)` implementation.
+- Correct IPv6 endpoint formatting in UAPI `endpoint=` lines (bracket
+  notation).
+- Preshared keys are now hex-encoded in the UAPI protocol (was incorrectly
+  passing base64).
+- Distinct `set_config()` and `sync_config()` methods: `set_config` does
+  atomic replace (`replace_peers=true`); `sync_config` diffs against running
+  state and applies only changes.
+- Extracted `_build_peer_uapi()` and `_send_uapi_set()` helpers.
+
+### Netlink backend (`wireguard_netlink.py`)
+
+- Refactored shared logic into `_apply_config()` used by both `set_config` and
+  `sync_config`.
+
+### Device abstraction (`wireguard_device.py`)
+
+- Added `sync_config()` to the abstract base class with a default fallback
+  to `set_config()`.
+
+### CLI (`cli.py`)
+
+- **`wg set`**: Full argument parser supporting `peer`, `endpoint`,
+  `allowed-ips` (replace and incremental), `preshared-key`,
+  `persistent-keepalive`, and `remove`.
+- **`wg addconf`** and **`wg syncconf`** subcommands.
+- **`wg show`** enhancements: `dump` format, per-field filtering, `interfaces`
+  mode, `WG_HIDE_KEYS` support.
+- **`wg-py up`** and **`wg-py down`** subcommands.
+
+### Pure-Python wg-quick (`wg_quick.py`) -- new module
+
+- `up()` and `down()` functions implementing `wg-quick(8)` using `pyroute2`
+  for netlink-based interface, address, route, and fwmark rule management.
+- DNS setup/teardown via `resolvconf`.
+- Pre/PostUp/Down hook execution with `WIREGUARD_INTERFACE` env var.
+- `Table = auto|off|<number>` routing logic with catch-all AllowedIPs
+  detection.
+
+### Privileged daemon (`daemon.py`, `daemon_client.py`) -- new modules
+
+- JSON-over-Unix-socket server (`wg-daemon`) enabling privilege separation.
+- 6 commands: `up`, `down`, `show`, `set_peer`, `remove_peer`, `list_devices`.
+- `WgDaemonClient` class for easy IPC from any Python consumer.
+- Systemd service template in `contrib/wg-daemon.service`.
+
+### Tests
+
+- 67 new tests across 5 test files:
+  - `test_cli_commands.py` (21): `_parse_set_args` and show field coverage
+  - `test_config_parsing.py` (26): endpoint parsing, comma lists, IPv6
+    roundtrip, FwMark hex, Table/SaveConfig
+  - `test_uapi_protocol.py` (12): peer UAPI serialization, set/sync config,
+    endpoint resolution
+  - `test_wg_quick.py` (11): config resolution, table routing, network
+    collection, up/down guards
+  - `test_daemon.py` (15): full protocol coverage with mocked privileged
+    operations
+
+### Other
+
+- Exposed `__version__` in `__init__.py`.
+- Added `wg-daemon` console script entry point.
+
+## v0.6.0 and earlier
+
+See the upstream [cmusatyalab/wireguard-tools](https://github.com/cmusatyalab/wireguard-tools)
+repository for prior release history.

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -1,0 +1,258 @@
+# wg-daemon -- Privileged Helper Daemon
+
+## Purpose
+
+`wg-daemon` is a thin JSON-over-Unix-socket server that runs with root
+privileges (or `CAP_NET_ADMIN`) and exposes WireGuard operations to
+unprivileged clients. This enables privilege separation: your web application,
+CLI tool, or automation script connects to the daemon socket instead of
+requiring root access itself.
+
+## Protocol
+
+The daemon listens on a Unix stream socket. Each client connection handles
+exactly one request-response cycle:
+
+1. Client connects to the socket
+2. Client sends a single JSON object followed by a newline
+3. Client shuts down the write side of the connection (`SHUT_WR`)
+4. Daemon processes the request and writes a JSON response followed by a newline
+5. Connection closes
+
+### Request Format
+
+```json
+{"cmd": "<command>", "args": {<arguments>}}
+```
+
+### Response Format
+
+Success:
+
+```json
+{"ok": true}
+```
+
+Success with data:
+
+```json
+{"ok": true, "data": <result>}
+```
+
+Error:
+
+```json
+{"ok": false, "error": "Human-readable error message"}
+```
+
+## Commands
+
+### up
+
+Bring up a WireGuard interface (equivalent to `wg-quick up`).
+
+```json
+{"cmd": "up", "args": {"interface": "wg0"}}
+```
+
+### down
+
+Bring down a WireGuard interface (equivalent to `wg-quick down`).
+
+```json
+{"cmd": "down", "args": {"interface": "wg0"}}
+```
+
+### show
+
+Query a WireGuard device and return its configuration as a dict.
+
+```json
+{"cmd": "show", "args": {"interface": "wg0"}}
+```
+
+Response `data` contains the full config dict (private key, listen port,
+fwmark, peers with their allowed IPs, endpoints, transfer stats, etc.).
+
+### set_peer
+
+Add or update a peer on a running interface.
+
+```json
+{
+  "cmd": "set_peer",
+  "args": {
+    "interface": "wg0",
+    "public_key": "base64encodedkey=",
+    "allowed_ips": ["10.0.0.2/32", "fd00::2/128"],
+    "endpoint_host": "203.0.113.1",
+    "endpoint_port": 51820,
+    "preshared_key": "base64encodedpsk=",
+    "persistent_keepalive": 25
+  }
+}
+```
+
+Only `interface` and `public_key` are required. All other fields are optional.
+
+### remove_peer
+
+Remove a peer from a running interface.
+
+```json
+{
+  "cmd": "remove_peer",
+  "args": {
+    "interface": "wg0",
+    "public_key": "base64encodedkey="
+  }
+}
+```
+
+### list_devices
+
+List all active WireGuard interfaces.
+
+```json
+{"cmd": "list_devices", "args": {}}
+```
+
+Response `data` is a list of interface name strings, e.g. `["wg0", "wg1"]`.
+
+## Configuration
+
+### Command-line flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--socket PATH` | `/var/run/wg-daemon.sock` | Unix socket path |
+| `--group NAME` | `wireguard` | Group ownership for socket file |
+| `-v, --verbose` | off | Enable debug logging |
+
+### Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `WG_DAEMON_SOCKET` | `/var/run/wg-daemon.sock` | Overrides default socket path (used by both daemon and client) |
+| `WG_DAEMON_GROUP` | `wireguard` | Overrides default group |
+
+## Systemd Setup
+
+A template service file is provided at `contrib/wg-daemon.service`.
+
+### Step-by-step installation
+
+1. Create the `wireguard` group:
+
+```bash
+sudo groupadd wireguard
+```
+
+1. Add your application user to the group:
+
+```bash
+sudo usermod -aG wireguard <app-user>
+```
+
+The user must log out and back in for the group membership to take effect.
+
+1. Install the service file:
+
+```bash
+sudo cp contrib/wg-daemon.service /etc/systemd/system/
+```
+
+1. Edit `ExecStart` to point at the virtualenv where wireguard-tools is
+   installed:
+
+```ini
+ExecStart=/home/<user>/wireguard-tools/.venv/bin/wg-daemon
+```
+
+1. Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now wg-daemon.service
+```
+
+1. Verify:
+
+```bash
+sudo systemctl status wg-daemon.service
+ls -la /var/run/wg-daemon.sock
+```
+
+The socket should be owned by `root:wireguard` with permissions `srw-rw----`.
+
+## Security Model
+
+### Socket permissions
+
+The daemon socket is created with mode `0660` and group-owned by the
+configured group (default: `wireguard`). Only root and members of this group
+can connect. This is the sole access control mechanism -- any process that can
+open the socket can execute any daemon command.
+
+### Systemd hardening
+
+The provided service file includes:
+
+| Directive | Value | Purpose |
+| --- | --- | --- |
+| `ProtectSystem` | `strict` | Mount `/usr`, `/boot`, `/efi` read-only |
+| `ProtectHome` | `read-only` | Prevent writes to `/home` |
+| `PrivateTmp` | `yes` | Isolate `/tmp` and `/var/tmp` |
+| `NoNewPrivileges` | `no` | Must be `no` because network operations require privileges |
+
+### What the daemon can do
+
+The daemon can create/destroy WireGuard interfaces, modify peers, and manage
+routes. It intentionally exposes a narrow API surface (6 commands) rather than
+arbitrary shell access.
+
+### What the daemon cannot do
+
+- It does not execute arbitrary commands
+- It does not read or write arbitrary files
+- It does not expose private keys over the socket (the `show` command returns
+  them in the config dict, but the socket is group-restricted)
+
+## Troubleshooting
+
+### Socket does not exist
+
+Check that the daemon is running:
+
+```bash
+sudo systemctl status wg-daemon.service
+sudo journalctl -u wg-daemon.service -n 50
+```
+
+### Permission denied connecting to socket
+
+Verify group membership:
+
+```bash
+groups <app-user>  # should include 'wireguard'
+ls -la /var/run/wg-daemon.sock  # should show srw-rw---- root wireguard
+```
+
+If you just added the user to the group, they need to log out and back in (or
+restart the application service).
+
+### Testing with socat
+
+Send a raw request to verify the daemon is responding:
+
+```bash
+echo '{"cmd":"list_devices","args":{}}' | socat - UNIX-CONNECT:/var/run/wg-daemon.sock
+```
+
+### Testing with Python
+
+```python
+from wireguard_tools.daemon_client import WgDaemonClient
+client = WgDaemonClient()
+print(client.list_devices())
+```

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,281 @@
+# Developer Integration Guide
+
+This guide covers using `wireguard-tools` as a Python library. For CLI usage,
+see the [README](../README.md). For daemon setup, see [DAEMON.md](DAEMON.md).
+
+## Installation
+
+```bash
+pip install wireguard-tools
+```
+
+Dependencies are minimal: `attrs`, `pyroute2`, and `segno` (for QR codes).
+
+## Quick Start
+
+### Key Generation and Derivation
+
+```python
+from wireguard_tools import WireguardKey
+
+private_key = WireguardKey.generate()
+public_key = private_key.public_key()
+
+print(f"Private: {private_key}")
+print(f"Public:  {public_key}")
+print(f"Hex:     {public_key.hex()}")
+print(f"URLsafe: {public_key.urlsafe}")
+```
+
+Parse an existing key from any encoding:
+
+```python
+key = WireguardKey("YpdTsMtb/QCdYKzHlzKkLcLzEbdTK0vP4ILmdcIvnhc=")  # base64
+key = WireguardKey("6297d3b0cb5bfd009d60acc79732a42dc2f311b7532b4bcfe082e675c22f9e17")  # hex
+```
+
+### Configuration Files
+
+**Parse a `.conf` file:**
+
+```python
+from wireguard_tools import WireguardConfig
+
+with open("/etc/wireguard/wg0.conf") as fh:
+    config = WireguardConfig.from_wgconfig(fh)
+
+print(f"Listen port: {config.listen_port}")
+print(f"Peers: {len(config.peers)}")
+
+for key, peer in config.peers.items():
+    print(f"  {peer.friendly_name or key}: {peer.allowed_ips}")
+```
+
+**Create a config programmatically:**
+
+```python
+from wireguard_tools import WireguardConfig, WireguardKey
+
+private = WireguardKey.generate()
+peer_pub = WireguardKey("YpdTsMtb/QCdYKzHlzKkLcLzEbdTK0vP4ILmdcIvnhc=")
+
+config = WireguardConfig.from_dict(dict(
+    private_key=str(private),
+    listen_port=51820,
+    addresses=["10.0.0.1/24"],
+    peers=[dict(
+        public_key=str(peer_pub),
+        allowed_ips=["10.0.0.2/32"],
+        endpoint_host="203.0.113.1",
+        endpoint_port=51820,
+        persistent_keepalive=25,
+    )],
+))
+```
+
+**Serialize:**
+
+```python
+# To wg-quick format (includes Address, DNS, Table, etc.)
+text = config.to_wgconfig(wgquick_format=True)
+
+# To plain WireGuard format (keys and peers only)
+text = config.to_wgconfig(wgquick_format=False)
+
+# To dict (for JSON/YAML serialization)
+d = config.asdict()
+
+# To QR code
+qr = config.to_qrcode()
+qr.save("peer-config.png")
+```
+
+### Device Operations
+
+Query and configure running WireGuard interfaces. Requires root.
+
+```python
+from wireguard_tools import WireguardDevice
+
+# List all WireGuard interfaces
+for device in WireguardDevice.list():
+    print(device.interface)
+
+# Get a specific device
+device = WireguardDevice.get("wg0")
+
+# Read current configuration (includes runtime stats)
+config = device.get_config()
+for key, peer in config.peers.items():
+    print(f"{key}: rx={peer.rx_bytes} tx={peer.tx_bytes}")
+
+# Apply a new configuration (atomic replace)
+device.set_config(new_config)
+
+# Apply changes incrementally (removes absent peers, skips unchanged)
+device.sync_config(new_config)
+
+device.close()
+```
+
+### wg-quick from Python
+
+Bring interfaces up and down. Requires root or `CAP_NET_ADMIN`.
+
+```python
+from wireguard_tools.wg_quick import up, down, WgQuickError
+
+try:
+    up("wg0")
+except WgQuickError as e:
+    print(f"Failed: {e}")
+
+# Later...
+down("wg0")
+```
+
+The `up()` function:
+
+- Reads `/etc/wireguard/wg0.conf` (or a full path to a `.conf` file)
+- Creates the WireGuard interface via netlink
+- Applies keys and peers via UAPI/Netlink
+- Assigns addresses, sets MTU, brings the link up
+- Installs routes for AllowedIPs
+- Configures DNS via `resolvconf` if specified
+- Runs Pre/PostUp hooks
+
+### Daemon Client
+
+Connect to `wg-daemon` from an unprivileged process. The daemon must be
+running separately (see [DAEMON.md](DAEMON.md)).
+
+```python
+from wireguard_tools.daemon_client import WgDaemonClient, DaemonError
+
+client = WgDaemonClient()  # uses WG_DAEMON_SOCKET or default path
+
+# Interface management
+client.up("wg0")
+client.down("wg0")
+
+# Query
+config_dict = client.show("wg0")
+interfaces = client.list_devices()
+
+# Peer management
+client.set_peer(
+    "wg0",
+    "base64pubkey=",
+    allowed_ips=["10.0.0.2/32"],
+    endpoint_host="203.0.113.1",
+    endpoint_port=51820,
+    persistent_keepalive=25,
+)
+client.remove_peer("wg0", "base64pubkey=")
+
+# Error handling
+try:
+    client.up("wg0")
+except DaemonError as e:
+    print(f"Daemon error: {e}")
+except ConnectionRefusedError:
+    print("Daemon is not running")
+```
+
+## API Reference
+
+### WireguardKey
+
+| Method | Description |
+| --- | --- |
+| `WireguardKey(value)` | Parse a key from base64, hex, urlsafe base64, or raw bytes |
+| `WireguardKey.generate()` | Generate a new Curve25519 private key |
+| `.public_key()` | Derive the corresponding public key |
+| `str(key)` | Base64-encoded string |
+| `.urlsafe` | URL-safe base64 (no padding) |
+| `.hex()` | Hexadecimal string |
+| `.keydata` | Raw 32-byte `bytes` |
+
+### WireguardPeer
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `public_key` | `WireguardKey` | Peer's public key (required) |
+| `preshared_key` | `WireguardKey` or `None` | Optional pre-shared key |
+| `endpoint_host` | `IPv4Address`, `IPv6Address`, `str`, or `None` | Endpoint hostname or IP |
+| `endpoint_port` | `int` or `None` | Endpoint port |
+| `persistent_keepalive` | `int` or `None` | Keepalive interval in seconds |
+| `allowed_ips` | `list` | List of `IPv4Interface`/`IPv6Interface` |
+| `friendly_name` | `str` or `None` | Human-readable label (from config comments) |
+| `friendly_json` | `dict` or `None` | Structured metadata (from config comments) |
+| `last_handshake` | `float` or `None` | Unix timestamp of last handshake (runtime only) |
+| `rx_bytes` | `int` or `None` | Bytes received (runtime only) |
+| `tx_bytes` | `int` or `None` | Bytes transmitted (runtime only) |
+
+| Method | Description |
+| --- | --- |
+| `.from_dict(d)` | Create from a dict (handles `endpoint` -> host/port split) |
+| `.from_wgconfig(kv)` | Create from parsed config key-value pairs |
+| `.asdict()` | Serialize to dict (non-None fields only) |
+| `.as_wgconfig_snippet()` | Serialize to config file lines |
+
+### WireguardConfig
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `private_key` | `WireguardKey` or `None` | Interface private key |
+| `listen_port` | `int` or `None` | UDP listen port |
+| `fwmark` | `int` or `None` | Firewall mark |
+| `peers` | `dict[WireguardKey, WireguardPeer]` | Peers keyed by public key |
+| `addresses` | `list` | Interface addresses (wg-quick) |
+| `dns_servers` | `list` | DNS servers (wg-quick) |
+| `mtu` | `int` or `None` | MTU (wg-quick) |
+| `table` | `str` or `None` | Routing table: `auto`, `off`, or number (wg-quick) |
+| `preup`, `postup`, `predown`, `postdown` | `list[str]` | Hook commands (wg-quick) |
+| `saveconfig` | `bool` | SaveConfig flag (wg-quick) |
+
+| Method | Description |
+| --- | --- |
+| `.from_wgconfig(fileobj)` | Parse a WireGuard config file |
+| `.from_dict(d)` | Create from a dict |
+| `.asdict()` | Serialize to dict |
+| `.to_wgconfig(wgquick_format=False)` | Serialize to config file string |
+| `.to_resolvconf()` | Generate `resolv.conf` content for DNS settings |
+| `.to_qrcode()` | Generate a `segno.QRCode` object |
+| `.add_peer(peer)` | Add or replace a peer |
+| `.del_peer(key)` | Remove a peer by public key |
+
+### WireguardDevice
+
+| Method | Description |
+| --- | --- |
+| `WireguardDevice.get(ifname)` | Open a device (UAPI first, then Netlink) |
+| `WireguardDevice.list()` | Iterate all WireGuard devices |
+| `.get_config()` | Read current device configuration |
+| `.set_config(config)` | Atomic replace (setconf) |
+| `.sync_config(config)` | Incremental update (syncconf) |
+| `.close()` | Release resources |
+
+### WgDaemonClient
+
+| Method | Description |
+| --- | --- |
+| `WgDaemonClient(socket_path=None)` | Connect to daemon (uses `WG_DAEMON_SOCKET` env var or default) |
+| `.up(interface)` | Bring up interface |
+| `.down(interface)` | Bring down interface |
+| `.show(interface)` | Query interface config (returns dict) |
+| `.set_peer(interface, public_key, **kwargs)` | Add/update peer |
+| `.remove_peer(interface, public_key)` | Remove peer |
+| `.list_devices()` | List active interfaces |
+
+Raises `DaemonError` on error responses, `ConnectionRefusedError` or
+`FileNotFoundError` if the daemon is not running.
+
+## Environment Variables
+
+| Variable | Used By | Default | Description |
+| --- | --- | --- | --- |
+| `WG_ENDPOINT_RESOLUTION_RETRIES` | UAPI backend | `15` | Max DNS retries for peer endpoints; `infinity` for unlimited |
+| `WG_HIDE_KEYS` | CLI (`wg show`) | (keys shown) | Set to `never` to display keys; any other value hides them |
+| `WG_DAEMON_SOCKET` | Daemon and client | `/var/run/wg-daemon.sock` | Unix socket path |
+| `WG_DAEMON_GROUP` | Daemon | `wireguard` | Socket group ownership |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ repository = "https://github.com/cmusatyalab/wireguard-tools"
 
 [project.scripts]
 wg-py = "wireguard_tools.cli:main"
+wg-daemon = "wireguard_tools.daemon:main"
 
 [dependency-groups]
 dev = [
@@ -101,6 +102,8 @@ ignore = ["ANN401", "COM812", "D", "S101"]
 "src/wireguard_tools/wireguard_config.py" = ["C901", "PLR0912"]
 "src/wireguard_tools/wg_quick.py" = ["C901", "PLR0912", "PLR0915", "S603"]
 "src/wireguard_tools/wireguard_device.py" = ["PLC0415"]
+"src/wireguard_tools/daemon.py" = ["C901", "PLR0912", "T201"]
+"src/wireguard_tools/daemon_client.py" = ["S101"]
 "tests/*" = ["PLR2004", "S101"]
 
 [tool.uv.build-backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "wireguard-tools"
-version = "0.6.0.post1"
+version = "0.7.0.dev0"
 description = "Pure python reimplementation of wireguard-tools"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -95,10 +95,11 @@ select = ["ALL"]
 ignore = ["ANN401", "COM812", "D", "S101"]
 
 [tool.ruff.lint.per-file-ignores]
-"src/wireguard_tools/cli.py" = ["FIX003", "T201", "TD"]
+"src/wireguard_tools/cli.py" = ["C901", "FIX003", "PLR0912", "PLR0915", "T201", "TD"]
 "src/wireguard_tools/curve25519.py" = ["N806"]
 "src/wireguard_tools/wireguard_uapi.py" = ["C901", "PLR0912"]
 "src/wireguard_tools/wireguard_config.py" = ["C901", "PLR0912"]
+"src/wireguard_tools/wg_quick.py" = ["C901", "PLR0912", "PLR0915", "S603"]
 "src/wireguard_tools/wireguard_device.py" = ["PLC0415"]
 "tests/*" = ["PLR2004", "S101"]
 

--- a/src/wireguard_tools/__init__.py
+++ b/src/wireguard_tools/__init__.py
@@ -4,6 +4,23 @@
 # Copyright (c) 2022-2024 Carnegie Mellon University
 # SPDX-License-Identifier: MIT
 #
+"""Pure-Python reimplementation of WireGuard userspace tools.
+
+This package provides a portable, dependency-light interface to
+WireGuard configuration, key management, and device control without
+requiring the C ``wireguard-tools`` binaries.
+
+Public API exports:
+
+* :class:`~wireguard_tools.wireguard_config.WireguardConfig` —
+  parse and generate ``wg(8)``-compatible configuration files.
+* :class:`~wireguard_tools.wireguard_config.WireguardPeer` —
+  represent a single peer section in a configuration.
+* :class:`~wireguard_tools.wireguard_device.WireguardDevice` —
+  interact with live WireGuard network interfaces.
+* :class:`~wireguard_tools.wireguard_key.WireguardKey` —
+  generate, derive, and serialise Curve25519 keys.
+"""
 
 from .wireguard_config import WireguardConfig, WireguardPeer
 from .wireguard_device import WireguardDevice

--- a/src/wireguard_tools/__init__.py
+++ b/src/wireguard_tools/__init__.py
@@ -9,4 +9,10 @@ from .wireguard_config import WireguardConfig, WireguardPeer
 from .wireguard_device import WireguardDevice
 from .wireguard_key import WireguardKey
 
-__all__ = ["WireguardConfig", "WireguardDevice", "WireguardKey", "WireguardPeer"]
+__version__ = "0.7.0.dev0"
+__all__ = [
+    "WireguardConfig",
+    "WireguardDevice",
+    "WireguardKey",
+    "WireguardPeer",
+]

--- a/src/wireguard_tools/__main__.py
+++ b/src/wireguard_tools/__main__.py
@@ -4,6 +4,11 @@
 # Copyright (c) 2022 Carnegie Mellon University
 # SPDX-License-Identifier: MIT
 #
+"""Entry point for ``python -m wireguard_tools``.
+
+Invoking this module as a script delegates to the CLI defined in
+:func:`wireguard_tools.cli.main` and exits with its return code.
+"""
 
 import sys
 

--- a/src/wireguard_tools/cli.py
+++ b/src/wireguard_tools/cli.py
@@ -361,7 +361,8 @@ def set_(args: argparse.Namespace) -> int:
             if "listen_port" in iface_params:
                 config.listen_port = iface_params["listen_port"]
             if "fwmark" in iface_params:
-                config.fwmark = iface_params["fwmark"] or None
+                # Keep explicit zero when user requests "fwmark off"/0.
+                config.fwmark = iface_params["fwmark"]
 
             for spec in peer_specs:
                 pub_key = spec["public_key"]

--- a/src/wireguard_tools/cli.py
+++ b/src/wireguard_tools/cli.py
@@ -5,6 +5,19 @@
 # SPDX-License-Identifier: MIT
 #
 
+"""Command-line interface for the pure-Python WireGuard tools.
+
+Provides subcommands that mirror the ``wg(8)`` utility: ``show``, ``showconf``,
+``set``, ``setconf``, ``addconf``, ``syncconf``, ``genkey``, ``genpsk``,
+``pubkey``, and ``strip``.  Additionally exposes ``up`` and ``down`` as
+convenience wrappers around the :mod:`wireguard_tools.wg_quick` module.
+
+Each public subcommand function accepts an :class:`argparse.Namespace` and
+returns an ``int`` exit code (``0`` for success, ``1`` for failure).  The
+module is intended to be invoked via :func:`main` or as
+``python -m wireguard_tools.cli``.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -40,9 +53,26 @@ SHOW_FIELDS = (
     "transfer",
     "dump",
 )
+"""Valid field names accepted by the ``wg show`` subcommand.
+
+When a single positional argument is passed to ``wg show`` and it matches one
+of these strings, it is interpreted as a *field selector* applied to every
+interface rather than an interface name.  The ``"dump"`` pseudo-field triggers
+the machine-readable tab-separated output format.
+"""
 
 
 def _format_endpoint(peer: WireguardPeer) -> str:
+    """Format a peer's endpoint as a human-readable ``host:port`` string.
+
+    IPv6 addresses are enclosed in brackets to disambiguate the colon-delimited
+    address from the port separator (e.g. ``[::1]:51820``).
+
+    :param peer: The peer whose endpoint should be formatted.
+    :returns: ``"(none)"`` when the peer has no endpoint configured, otherwise
+        a ``host:port`` string.
+    :rtype: str
+    """
     if peer.endpoint_host is None:
         return "(none)"
     host = peer.endpoint_host
@@ -54,6 +84,21 @@ def _format_endpoint(peer: WireguardPeer) -> str:
 def _show_pretty(
     device: WireguardDevice, config: WireguardConfig, hide_keys: bool
 ) -> None:
+    """Print a human-readable summary of an interface and its peers to stdout.
+
+    The output mirrors the default ``wg show <interface>`` format: interface-level
+    fields (public key, private key, listening port, fwmark) followed by a blank
+    line and per-peer blocks (preshared key, endpoint, keepalive, allowed IPs,
+    latest handshake, transfer statistics).
+
+    :param device: The device whose name will be shown in the ``interface:``
+        header line.
+    :param config: The configuration snapshot to render.
+    :param hide_keys: When ``True``, private and preshared keys are replaced
+        with ``"(hidden)"``.  Controlled by the ``WG_HIDE_KEYS`` environment
+        variable at the call-site.
+    :rtype: None
+    """
     print(f"interface: {device.interface}")
     if config.private_key is not None:
         print(f"  public key: {config.private_key.public_key()}")
@@ -93,6 +138,20 @@ def _show_pretty(
 def _show_dump(
     device: WireguardDevice, config: WireguardConfig, prefix_iface: bool
 ) -> None:
+    """Print the machine-readable tab-separated dump of an interface.
+
+    The first line contains interface-level fields
+    (``private-key  public-key  listen-port  fwmark``) and each subsequent line
+    contains per-peer fields (``public-key  preshared-key  endpoint  allowed-ips
+    latest-handshake  rx  tx  persistent-keepalive``).  When *prefix_iface* is
+    ``True`` every line is prefixed with the interface name — this is the format
+    used by ``wg show all dump``.
+
+    :param device: The device providing the interface name.
+    :param config: The configuration snapshot to render.
+    :param prefix_iface: Prepend ``<ifname>\\t`` to every output line.
+    :rtype: None
+    """
     pfx = f"{device.interface}\t" if prefix_iface else ""
     private_key = str(config.private_key) if config.private_key else "(none)"
     public_key = (
@@ -122,6 +181,20 @@ def _show_field(
     field: str,
     prefix_iface: bool,
 ) -> None:
+    """Print a single field value for an interface and its peers.
+
+    For interface-level fields (``public-key``, ``private-key``, ``listen-port``,
+    ``fwmark``) one line is emitted.  For per-peer fields (``peers``,
+    ``preshared-keys``, ``endpoints``, ``allowed-ips``, ``latest-handshakes``,
+    ``persistent-keepalive``, ``transfer``) one line is emitted per peer.
+
+    :param device: The device providing the interface name.
+    :param config: The configuration snapshot to render.
+    :param field: One of the :data:`SHOW_FIELDS` names (excluding ``"dump"``
+        which is handled by :func:`_show_dump`).
+    :param prefix_iface: Prepend ``<ifname>\\t`` to every output line.
+    :rtype: None
+    """
     pfx = f"{device.interface}\t" if prefix_iface else ""
     if field == "public-key":
         if config.private_key:
@@ -165,7 +238,27 @@ def _show_field(
 def _resolve_show_args(
     show_args: list[str],
 ) -> tuple[str | None, str | None]:
-    """Resolve `wg show` positional arguments into (interface, field)."""
+    """Resolve ``wg show`` positional arguments into an (interface, field) pair.
+
+    Disambiguation rules:
+
+    * **No arguments** — show all interfaces in pretty mode:
+      ``(None, None)``.
+    * **One argument that matches a** :data:`SHOW_FIELDS` **name** — treat it
+      as a field selector for every interface: ``(None, field)``.
+    * **One argument that does** *not* **match a field** — treat it as an
+      interface name: ``(interface, None)``.
+    * **Two arguments** — first is the interface, second must be a valid field:
+      ``(interface, field)``.
+
+    :param show_args: Positional arguments from the ``wg show`` invocation
+        (0–2 items).
+    :returns: A ``(interface, field)`` tuple where either element may be
+        ``None``.
+    :rtype: tuple[str | None, str | None]
+    :raises ValueError: If more than two positional arguments are provided or
+        the second argument is not a recognised field name.
+    """
     if len(show_args) > 2:
         msg = "Usage: wg show [<interface>|all|interfaces] [<field>]"
         raise ValueError(msg)
@@ -184,7 +277,24 @@ def _resolve_show_args(
 
 
 def show(args: argparse.Namespace) -> int:
-    """Show the current configuration and device information."""
+    """Display current WireGuard interface configuration and runtime state.
+
+    Implements the ``wg show`` subcommand.  Behaviour depends on the positional
+    arguments resolved by :func:`_resolve_show_args`:
+
+    * No interface and no field — pretty-print every interface.
+    * ``"interfaces"`` — list interface names only.
+    * ``"all"`` or no interface with a field — iterate all interfaces showing
+      the requested field.
+    * Specific interface, optional field — show that interface.
+
+    Keys are hidden by default; set ``WG_HIDE_KEYS=never`` to reveal them.
+
+    :param args: Parsed CLI namespace.  May contain a ``show_args`` attribute
+        with 0–2 positional strings.
+    :returns: ``0`` on success, ``1`` on error.
+    :rtype: int
+    """
     hide_keys = os.environ.get("WG_HIDE_KEYS", "always") != "never"
     try:
         interface, field = _resolve_show_args(getattr(args, "show_args", []))
@@ -227,7 +337,17 @@ def show(args: argparse.Namespace) -> int:
 
 
 def showconf(args: argparse.Namespace) -> int:
-    """Show the configuration of a WireGuard interface, for use with `setconf`."""
+    """Print the running configuration of a WireGuard interface in ``wg`` config format.
+
+    The output is suitable for piping into ``wg setconf`` or saving to a
+    ``.conf`` file.  Runtime-only state (transfer counters, handshake
+    timestamps) is *not* included.
+
+    :param args: Parsed CLI namespace with an ``interface`` attribute naming the
+        WireGuard device to query.
+    :returns: ``0`` on success, ``1`` on error.
+    :rtype: int
+    """
     try:
         with closing(WireguardDevice.get(args.interface)) as device:
             config = device.get_config()
@@ -239,7 +359,21 @@ def showconf(args: argparse.Namespace) -> int:
 
 
 def _read_key_file(path: str) -> WireguardKey | None:
-    """Read a key from a file path. Returns None for /dev/null or empty files."""
+    """Read a WireGuard key from a file path.
+
+    Used by ``wg set`` for ``--private-key`` and ``--preshared-key`` options
+    where the value is a filesystem path rather than a literal key string.
+    ``/dev/null`` is the conventional way to *clear* a key.
+
+    :param path: Filesystem path to the key file, or ``"/dev/null"`` to
+        indicate that the key should be removed.
+    :returns: A :class:`~wireguard_tools.wireguard_key.WireguardKey` parsed
+        from the file contents, or ``None`` if *path* is ``"/dev/null"`` or
+        the file is empty.
+    :rtype: WireguardKey | None
+    :raises FileNotFoundError: If *path* does not exist.
+    :raises ValueError: If the file contents are not a valid WireGuard key.
+    """
     if path == "/dev/null":
         return None
     with open(path) as f:
@@ -252,9 +386,51 @@ def _read_key_file(path: str) -> WireguardKey | None:
 def _parse_set_args(
     argv: list[str],
 ) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
-    """Parse the ``wg set`` argument syntax.
+    """Parse the ``wg set`` argument vector into structured parameters.
 
-    Returns (interface, iface_params, peers).
+    The grammar mirrors the ``wg(8)`` man-page::
+
+        wg set <interface>
+            [listen-port <port>]
+            [fwmark <fwmark> | off]
+            [private-key <file-path>]
+            [peer <base64-public-key>
+                [remove]
+                [preshared-key <file-path>]
+                [endpoint <host>:<port>]
+                [persistent-keepalive <interval> | off]
+                [allowed-ips <ip1>[,<ip2>]... ]
+            ]...
+
+    **allowed-ips modes:**
+
+    * *Replace mode* (default) — a plain comma-separated list replaces the
+      peer's entire allowed-ips set.  An empty string clears the list.
+    * *Incremental mode* — when *any* entry carries a ``+`` or ``-`` prefix,
+      the list is interpreted incrementally: ``+``-prefixed (or bare) addresses
+      are added and ``-``-prefixed addresses are removed.
+
+    **Clearing semantics:**
+
+    * ``fwmark off`` sets ``fwmark`` to ``0``.
+    * ``persistent-keepalive off`` sets the value to ``0`` (disabled).
+    * ``private-key /dev/null`` clears the private key (see
+      :func:`_read_key_file`).
+
+    :param argv: Raw argument list *including* the interface name as the first
+        element (``args.remaining`` from the CLI parser).
+    :returns: A three-tuple ``(interface, iface_params, peers)`` where
+        *iface_params* is a ``dict`` of interface-level settings and *peers*
+        is a ``list`` of ``dict`` objects each keyed by ``public_key`` with
+        optional ``remove``, ``preshared_key``, ``endpoint_host``,
+        ``endpoint_port``, ``persistent_keepalive``, ``allowed_ips``,
+        ``replace_allowed_ips``, ``add_allowed_ips``, and
+        ``remove_allowed_ips`` entries.
+    :rtype: tuple[str, dict[str, Any], list[dict[str, Any]]]
+    :raises ValueError: On unknown tokens, out-of-order peer options, or
+        missing values.
+    :raises IndexError: If a keyword token is the last element and its
+        required value is missing.
     """
     if not argv:
         msg = "Usage: wg set <interface> [listen-port <port>] ..."
@@ -345,7 +521,27 @@ def _parse_set_args(
 
 
 def set_(args: argparse.Namespace) -> int:
-    """Change the current configuration, add peers, remove peers, or change peers."""
+    """Apply in-place mutations to a live WireGuard interface.
+
+    Implements the ``wg set`` subcommand.  Reads the current device
+    configuration, merges in the changes described by the raw argument vector
+    (parsed by :func:`_parse_set_args`), and writes the result back.
+
+    **Mutation semantics:**
+
+    * ``fwmark 0`` / ``fwmark off`` — clears the firewall mark (stored as
+      ``0``).
+    * ``persistent-keepalive 0`` / ``persistent-keepalive off`` — disables
+      keepalive (stored as ``None``).
+    * ``peer <key> remove`` — deletes the peer entirely.
+    * ``allowed-ips`` in *replace* mode overwrites the peer's list; in
+      *incremental* mode individual addresses are added or removed.
+
+    :param args: Parsed CLI namespace with a ``remaining`` attribute containing
+        the unparsed ``wg set`` arguments.
+    :returns: ``0`` on success, ``1`` on error.
+    :rtype: int
+    """
     try:
         interface, iface_params, peer_specs = _parse_set_args(args.remaining)
     except (ValueError, IndexError) as exc:
@@ -404,7 +600,17 @@ def set_(args: argparse.Namespace) -> int:
 
 
 def setconf(args: argparse.Namespace) -> int:
-    """Apply a configuration file to a WireGuard interface."""
+    """Replace the entire configuration of a WireGuard interface from a file.
+
+    Implements the ``wg setconf`` subcommand.  The file is parsed as a standard
+    ``wg``-format configuration and applied atomically — any peers present on
+    the device but absent from the file are removed.
+
+    :param args: Parsed CLI namespace with ``interface`` (device name) and
+        ``configfile`` (open file handle) attributes.
+    :returns: ``0`` on success, ``1`` on error.
+    :rtype: int
+    """
     try:
         config = WireguardConfig.from_wgconfig(args.configfile)
         with closing(WireguardDevice.get(args.interface)) as device:
@@ -416,7 +622,18 @@ def setconf(args: argparse.Namespace) -> int:
 
 
 def addconf(args: argparse.Namespace) -> int:
-    """Append a configuration file to a WireGuard interface."""
+    """Merge a configuration file into an existing WireGuard interface.
+
+    Implements the ``wg addconf`` subcommand.  Unlike :func:`setconf`, existing
+    peers that are not mentioned in the file are left untouched.  Interface-level
+    settings (``private_key``, ``listen_port``, ``fwmark``) from the file
+    override the current values only when explicitly provided (i.e. non-``None``).
+
+    :param args: Parsed CLI namespace with ``interface`` (device name) and
+        ``configfile`` (open file handle) attributes.
+    :returns: ``0`` on success, ``1`` on error.
+    :rtype: int
+    """
     try:
         new_config = WireguardConfig.from_wgconfig(args.configfile)
         with closing(WireguardDevice.get(args.interface)) as device:
@@ -440,7 +657,18 @@ def addconf(args: argparse.Namespace) -> int:
 
 
 def syncconf(args: argparse.Namespace) -> int:
-    """Synchronize a configuration file with a WireGuard interface."""
+    """Synchronize a WireGuard interface to match a configuration file.
+
+    Implements the ``wg syncconf`` subcommand.  This is similar to
+    :func:`setconf` but uses the device-level ``sync_config`` method, which
+    preserves runtime state (e.g. latest-handshake, transfer counters) for
+    peers whose configuration has not changed.
+
+    :param args: Parsed CLI namespace with ``interface`` (device name) and
+        ``configfile`` (open file handle) attributes.
+    :returns: ``0`` on success, ``1`` on error.
+    :rtype: int
+    """
     try:
         config = WireguardConfig.from_wgconfig(args.configfile)
         with closing(WireguardDevice.get(args.interface)) as device:
@@ -452,14 +680,30 @@ def syncconf(args: argparse.Namespace) -> int:
 
 
 def _check_stdout() -> None:
-    """Check and warn if stdout is a world accessible file."""
+    """Warn on stderr if stdout is redirected to a world-accessible file.
+
+    Called before writing sensitive key material to stdout.  If stdout is a
+    regular file whose permissions include *any* bits in ``S_IRWXO`` (other
+    read/write/execute), a warning is emitted to stderr.  This mirrors the
+    safety check in the upstream C ``wg`` implementation.
+
+    :rtype: None
+    """
     stat = os.fstat(sys.stdout.fileno())
     if S_ISREG(stat.st_mode) and (stat.st_mode & S_IRWXO):
         print("Warning: writing to world accessible file.", file=sys.stderr)
 
 
 def genkey(_args: argparse.Namespace) -> int:
-    """Generate a new private key and write it to stdout."""
+    """Generate a new Curve25519 private key and write it to stdout.
+
+    Implements the ``wg genkey`` subcommand.  Emits a warning via
+    :func:`_check_stdout` if stdout is world-readable.
+
+    :param _args: Parsed CLI namespace (unused).
+    :returns: ``0`` unconditionally.
+    :rtype: int
+    """
     _check_stdout()
     secret_key = WireguardKey.generate()
     print(secret_key)
@@ -467,7 +711,16 @@ def genkey(_args: argparse.Namespace) -> int:
 
 
 def genpsk(_args: argparse.Namespace) -> int:
-    """Generate a new preshared key and write it to stdout."""
+    """Generate a new 256-bit preshared key and write it to stdout.
+
+    Implements the ``wg genpsk`` subcommand.  The key is derived from 32 bytes
+    of cryptographically secure random data (:func:`secrets.token_bytes`).
+    Emits a warning via :func:`_check_stdout` if stdout is world-readable.
+
+    :param _args: Parsed CLI namespace (unused).
+    :returns: ``0`` unconditionally.
+    :rtype: int
+    """
     _check_stdout()
     random_data = token_bytes(32)
     preshared_key = WireguardKey(random_data)
@@ -476,7 +729,16 @@ def genpsk(_args: argparse.Namespace) -> int:
 
 
 def pubkey(_args: argparse.Namespace) -> int:
-    """Read a private key from stdin and write a public key to stdout."""
+    """Derive a Curve25519 public key from a private key read on stdin.
+
+    Implements the ``wg pubkey`` subcommand.  Reads the entirety of stdin,
+    interprets it as a base64-encoded private key, computes the corresponding
+    public key, and prints it to stdout.
+
+    :param _args: Parsed CLI namespace (unused).
+    :returns: ``0`` unconditionally.
+    :rtype: int
+    """
     private_key = sys.stdin.read()
     public_key = WireguardKey(private_key).public_key()
     print(public_key)
@@ -484,14 +746,35 @@ def pubkey(_args: argparse.Namespace) -> int:
 
 
 def strip(args: argparse.Namespace) -> int:
-    """Output a configuration file with all wg-quick specific options removed."""
+    """Print a configuration file stripped of ``wg-quick``-specific options.
+
+    Implements the ``wg strip`` subcommand.  Parses the input file and
+    re-serialises it using :meth:`WireguardConfig.to_wgconfig`, which omits
+    directives such as ``Address``, ``DNS``, ``MTU``, ``Table``, and
+    hook commands (``PreUp``, ``PostUp``, ``PreDown``, ``PostDown``).
+
+    :param args: Parsed CLI namespace with a ``configfile`` (open file handle)
+        attribute.
+    :returns: ``0`` unconditionally.
+    :rtype: int
+    """
     config = WireguardConfig.from_wgconfig(args.configfile)
     print(config.to_wgconfig())
     return 0
 
 
 def up(args: argparse.Namespace) -> int:
-    """Create and configure a WireGuard interface from a config file."""
+    """Bring up a WireGuard interface via ``wg-quick``.
+
+    Implements the ``wg-py up`` subcommand by delegating to
+    :func:`wireguard_tools.wg_quick.up`.  Creates the interface, applies
+    configuration, sets addresses/routes, and runs lifecycle hooks.
+
+    :param args: Parsed CLI namespace with an ``interface`` attribute (name
+        or path to a ``.conf`` file).
+    :returns: ``0`` on success, ``1`` if :class:`WgQuickError` is raised.
+    :rtype: int
+    """
     from .wg_quick import WgQuickError, up as wg_up
 
     try:
@@ -503,7 +786,18 @@ def up(args: argparse.Namespace) -> int:
 
 
 def down(args: argparse.Namespace) -> int:
-    """Tear down a WireGuard interface."""
+    """Tear down a WireGuard interface via ``wg-quick``.
+
+    Implements the ``wg-py down`` subcommand by delegating to
+    :func:`wireguard_tools.wg_quick.down`.  Runs pre-down hooks, removes DNS
+    configuration, deletes routing rules and routes, destroys the interface,
+    and runs post-down hooks.
+
+    :param args: Parsed CLI namespace with an ``interface`` attribute (name
+        or path to a ``.conf`` file).
+    :returns: ``0`` on success, ``1`` if :class:`WgQuickError` is raised.
+    :rtype: int
+    """
     from .wg_quick import WgQuickError, down as wg_down
 
     try:
@@ -515,6 +809,17 @@ def down(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
+    """Parse command-line arguments and dispatch to the appropriate subcommand.
+
+    Entry point for the ``wg-py`` console script.  Builds an
+    :class:`argparse.ArgumentParser` with one sub-parser per subcommand, parses
+    ``sys.argv``, and invokes the handler function stored in the ``func``
+    default.
+
+    :returns: The exit code returned by the dispatched subcommand, or the
+        result of printing help when no subcommand is given.
+    :rtype: int
+    """
     parser = argparse.ArgumentParser(prog="wg-py")
     parser.set_defaults(func=lambda _: parser.print_help())
 

--- a/src/wireguard_tools/cli.py
+++ b/src/wireguard_tools/cli.py
@@ -11,28 +11,185 @@ import argparse
 import os
 import sys
 from contextlib import closing
-from importlib.metadata import version
+from ipaddress import IPv6Address, ip_interface
 from secrets import token_bytes
 from stat import S_IRWXO, S_ISREG
-from typing import Iterable
+from typing import Any, Iterable
 
-from .wireguard_config import WireguardConfig
+from .wireguard_config import WireguardConfig, WireguardPeer, _parse_endpoint
 from .wireguard_device import WireguardDevice
 from .wireguard_key import WireguardKey
 
 
+SHOW_FIELDS = (
+    "public-key",
+    "private-key",
+    "listen-port",
+    "fwmark",
+    "peers",
+    "preshared-keys",
+    "endpoints",
+    "allowed-ips",
+    "latest-handshakes",
+    "persistent-keepalive",
+    "transfer",
+    "dump",
+)
+
+
+def _format_endpoint(peer: WireguardPeer) -> str:
+    if peer.endpoint_host is None:
+        return "(none)"
+    host = peer.endpoint_host
+    if isinstance(host, IPv6Address):
+        return f"[{host}]:{peer.endpoint_port}"
+    return f"{host}:{peer.endpoint_port}"
+
+
+def _show_pretty(
+    device: WireguardDevice, config: WireguardConfig, hide_keys: bool
+) -> None:
+    print(f"interface: {device.interface}")
+    if config.private_key is not None:
+        print(f"  public key: {config.private_key.public_key()}")
+        print(f"  private key: {'(hidden)' if hide_keys else config.private_key}")
+    if config.listen_port is not None:
+        print(f"  listening port: {config.listen_port}")
+    if config.fwmark is not None:
+        print(f"  fwmark: {config.fwmark:#x}")
+    print()
+
+    for peer in config.peers.values():
+        print(f"peer: {peer.public_key}")
+        if peer.preshared_key:
+            print(
+                f"  preshared key: {'(hidden)' if hide_keys else peer.preshared_key}"
+            )
+        if peer.endpoint_host:
+            print(f"  endpoint: {_format_endpoint(peer)}")
+        if peer.persistent_keepalive:
+            print(
+                f"  persistent keepalive: every {peer.persistent_keepalive} seconds"
+            )
+        if peer.allowed_ips:
+            allowed_ips = ", ".join(str(addr) for addr in peer.allowed_ips)
+            print(f"  allowed ips: {allowed_ips}")
+        if peer.last_handshake:
+            print(f"  latest handshake: {peer.last_handshake}")
+        if peer.rx_bytes is not None and peer.tx_bytes is not None:
+            print(
+                "  transfer:"
+                f" {peer.rx_bytes / 1024:.2f} KiB received,"
+                f" {peer.tx_bytes / 1024:.2f} KiB sent",
+            )
+        print()
+
+
+def _show_dump(
+    device: WireguardDevice, config: WireguardConfig, prefix_iface: bool
+) -> None:
+    pfx = f"{device.interface}\t" if prefix_iface else ""
+    private_key = str(config.private_key) if config.private_key else "(none)"
+    public_key = (
+        str(config.private_key.public_key()) if config.private_key else "(none)"
+    )
+    listen_port = config.listen_port if config.listen_port else 0
+    fwmark = f"0x{config.fwmark:x}" if config.fwmark else "off"
+    print(f"{pfx}{private_key}\t{public_key}\t{listen_port}\t{fwmark}")
+
+    for peer in config.peers.values():
+        psk = str(peer.preshared_key) if peer.preshared_key else "(none)"
+        endpoint = _format_endpoint(peer)
+        allowed = ", ".join(str(a) for a in peer.allowed_ips) or "(none)"
+        handshake = int(peer.last_handshake) if peer.last_handshake else 0
+        rx = peer.rx_bytes or 0
+        tx = peer.tx_bytes or 0
+        keepalive = peer.persistent_keepalive if peer.persistent_keepalive else "off"
+        print(
+            f"{pfx}{peer.public_key}\t{psk}\t{endpoint}\t{allowed}"
+            f"\t{handshake}\t{rx}\t{tx}\t{keepalive}"
+        )
+
+
+def _show_field(
+    device: WireguardDevice,
+    config: WireguardConfig,
+    field: str,
+    prefix_iface: bool,
+) -> None:
+    pfx = f"{device.interface}\t" if prefix_iface else ""
+    if field == "public-key":
+        if config.private_key:
+            print(f"{pfx}{config.private_key.public_key()}")
+    elif field == "private-key":
+        if config.private_key:
+            print(f"{pfx}{config.private_key}")
+    elif field == "listen-port":
+        print(f"{pfx}{config.listen_port or 0}")
+    elif field == "fwmark":
+        print(f"{pfx}{f'0x{config.fwmark:x}' if config.fwmark else 'off'}")
+    elif field == "peers":
+        for peer in config.peers.values():
+            print(f"{pfx}{peer.public_key}")
+    elif field == "preshared-keys":
+        for peer in config.peers.values():
+            psk = str(peer.preshared_key) if peer.preshared_key else "(none)"
+            print(f"{pfx}{peer.public_key}\t{psk}")
+    elif field == "endpoints":
+        for peer in config.peers.values():
+            print(f"{pfx}{peer.public_key}\t{_format_endpoint(peer)}")
+    elif field == "allowed-ips":
+        for peer in config.peers.values():
+            allowed = ", ".join(str(a) for a in peer.allowed_ips) or "(none)"
+            print(f"{pfx}{peer.public_key}\t{allowed}")
+    elif field == "latest-handshakes":
+        for peer in config.peers.values():
+            hs = int(peer.last_handshake) if peer.last_handshake else 0
+            print(f"{pfx}{peer.public_key}\t{hs}")
+    elif field == "persistent-keepalive":
+        for peer in config.peers.values():
+            ka = peer.persistent_keepalive if peer.persistent_keepalive else "off"
+            print(f"{pfx}{peer.public_key}\t{ka}")
+    elif field == "transfer":
+        for peer in config.peers.values():
+            rx = peer.rx_bytes or 0
+            tx = peer.tx_bytes or 0
+            print(f"{pfx}{peer.public_key}\t{rx}\t{tx}")
+
+
 def show(args: argparse.Namespace) -> int:
     """Show the current configuration and device information."""
+    hide_keys = os.environ.get("WG_HIDE_KEYS", "always") != "never"
+    interface = args.interface
+    field = getattr(args, "field", None)
+
+    if interface == "interfaces":
+        try:
+            for dev in WireguardDevice.list():
+                print(dev.interface)
+                dev.close()
+            return 0
+        except RuntimeError as exc:
+            print(exc, file=sys.stderr)
+            return 1
+
     try:
-        if args.interface is None:
+        show_all = interface is None or interface == "all"
+        if show_all:
             devices: Iterable[WireguardDevice] = WireguardDevice.list()
         else:
-            devices = [WireguardDevice.get(args.interface)]
+            devices = [WireguardDevice.get(interface)]
 
         for device in devices:
-            print(f"interface: {device.interface}")
-            print(device.get_config())
+            config = device.get_config()
             device.close()
+
+            if field is None:
+                _show_pretty(device, config, hide_keys)
+            elif field == "dump":
+                _show_dump(device, config, prefix_iface=show_all)
+            else:
+                _show_field(device, config, field, prefix_iface=show_all)
     except RuntimeError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -52,15 +209,172 @@ def showconf(args: argparse.Namespace) -> int:
         return 1
 
 
-def set_(_args: argparse.Namespace) -> int:
+def _read_key_file(path: str) -> WireguardKey | None:
+    """Read a key from a file path. Returns None for /dev/null or empty files."""
+    if path == "/dev/null":
+        return None
+    with open(path) as f:
+        data = f.read().strip()
+    if not data:
+        return None
+    return WireguardKey(data)
+
+
+def _parse_set_args(
+    argv: list[str],
+) -> tuple[str, dict[str, Any], list[dict[str, Any]]]:
+    """Parse the ``wg set`` argument syntax.
+
+    Returns (interface, iface_params, peers).
+    """
+    if not argv:
+        msg = "Usage: wg set <interface> [listen-port <port>] ..."
+        raise ValueError(msg)
+
+    interface = argv[0]
+    iface_params: dict[str, Any] = {}
+    peers: list[dict[str, Any]] = []
+    current_peer: dict[str, Any] | None = None
+    i = 1
+
+    while i < len(argv):
+        token = argv[i]
+
+        if token == "listen-port":
+            i += 1
+            iface_params["listen_port"] = int(argv[i])
+        elif token == "fwmark":
+            i += 1
+            val = argv[i]
+            iface_params["fwmark"] = 0 if val == "off" else int(val, 0)
+        elif token == "private-key":
+            i += 1
+            iface_params["private_key"] = _read_key_file(argv[i])
+        elif token == "peer":
+            i += 1
+            current_peer = {"public_key": WireguardKey(argv[i])}
+            peers.append(current_peer)
+        elif token == "remove":
+            if current_peer is None:
+                msg = "'remove' must follow a 'peer' specification"
+                raise ValueError(msg)
+            current_peer["remove"] = True
+        elif token == "preshared-key":
+            if current_peer is None:
+                msg = "'preshared-key' must follow a 'peer' specification"
+                raise ValueError(msg)
+            i += 1
+            current_peer["preshared_key"] = _read_key_file(argv[i])
+        elif token == "endpoint":
+            if current_peer is None:
+                msg = "'endpoint' must follow a 'peer' specification"
+                raise ValueError(msg)
+            i += 1
+            host, port = _parse_endpoint(argv[i])
+            current_peer["endpoint_host"] = host
+            current_peer["endpoint_port"] = port
+        elif token == "persistent-keepalive":
+            if current_peer is None:
+                msg = "'persistent-keepalive' must follow a 'peer' specification"
+                raise ValueError(msg)
+            i += 1
+            val = argv[i]
+            current_peer["persistent_keepalive"] = 0 if val == "off" else int(val)
+        elif token == "allowed-ips":
+            if current_peer is None:
+                msg = "'allowed-ips' must follow a 'peer' specification"
+                raise ValueError(msg)
+            i += 1
+            raw = argv[i]
+            if not raw:
+                current_peer["allowed_ips"] = []
+                current_peer["replace_allowed_ips"] = True
+            else:
+                entries = [e.strip() for e in raw.split(",")]
+                has_prefix = any(e.startswith(("+", "-")) for e in entries if e)
+                if has_prefix:
+                    add_ips: list[Any] = []
+                    remove_ips: list[Any] = []
+                    for entry in entries:
+                        if entry.startswith("-"):
+                            remove_ips.append(ip_interface(entry[1:]))
+                        elif entry.startswith("+"):
+                            add_ips.append(ip_interface(entry[1:]))
+                        else:
+                            add_ips.append(ip_interface(entry))
+                    current_peer["add_allowed_ips"] = add_ips
+                    current_peer["remove_allowed_ips"] = remove_ips
+                else:
+                    current_peer["allowed_ips"] = [ip_interface(e) for e in entries]
+                    current_peer["replace_allowed_ips"] = True
+        else:
+            msg = f"Unknown option: {token}"
+            raise ValueError(msg)
+        i += 1
+
+    return interface, iface_params, peers
+
+
+def set_(args: argparse.Namespace) -> int:
     """Change the current configuration, add peers, remove peers, or change peers."""
-    print("Not implemented yet")
-    return 1
+    try:
+        interface, iface_params, peer_specs = _parse_set_args(args.remaining)
+    except (ValueError, IndexError) as exc:
+        print(f"Invalid arguments: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        with closing(WireguardDevice.get(interface)) as device:
+            config = device.get_config()
+
+            if "private_key" in iface_params:
+                config.private_key = iface_params["private_key"]
+            if "listen_port" in iface_params:
+                config.listen_port = iface_params["listen_port"]
+            if "fwmark" in iface_params:
+                config.fwmark = iface_params["fwmark"] or None
+
+            for spec in peer_specs:
+                pub_key = spec["public_key"]
+
+                if spec.get("remove"):
+                    config.peers.pop(pub_key, None)
+                    continue
+
+                if pub_key in config.peers:
+                    peer = config.peers[pub_key]
+                else:
+                    peer = WireguardPeer(public_key=pub_key)
+                    config.add_peer(peer)
+
+                if "preshared_key" in spec:
+                    peer.preshared_key = spec["preshared_key"]
+                if "endpoint_host" in spec:
+                    peer.endpoint_host = spec["endpoint_host"]
+                    peer.endpoint_port = spec["endpoint_port"]
+                if "persistent_keepalive" in spec:
+                    val = spec["persistent_keepalive"]
+                    peer.persistent_keepalive = val if val else None
+
+                if spec.get("replace_allowed_ips"):
+                    peer.allowed_ips = spec.get("allowed_ips", [])
+                else:
+                    for ip in spec.get("add_allowed_ips", []):
+                        if ip not in peer.allowed_ips:
+                            peer.allowed_ips.append(ip)
+                    for ip in spec.get("remove_allowed_ips", []):
+                        if ip in peer.allowed_ips:
+                            peer.allowed_ips.remove(ip)
+
+            device.set_config(config)
+            return 0
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 1
 
 
 def setconf(args: argparse.Namespace) -> int:
     """Apply a configuration file to a WireGuard interface."""
-    # XXX our device.set_config implicitly does a syncconf
     try:
         config = WireguardConfig.from_wgconfig(args.configfile)
         with closing(WireguardDevice.get(args.interface)) as device:
@@ -71,10 +385,28 @@ def setconf(args: argparse.Namespace) -> int:
         return 1
 
 
-def addconf(_args: argparse.Namespace) -> int:
+def addconf(args: argparse.Namespace) -> int:
     """Append a configuration file to a WireGuard interface."""
-    print("Not implemented yet")
-    return 1
+    try:
+        new_config = WireguardConfig.from_wgconfig(args.configfile)
+        with closing(WireguardDevice.get(args.interface)) as device:
+            config = device.get_config()
+
+            if new_config.private_key is not None:
+                config.private_key = new_config.private_key
+            if new_config.listen_port is not None:
+                config.listen_port = new_config.listen_port
+            if new_config.fwmark is not None:
+                config.fwmark = new_config.fwmark
+
+            for peer in new_config.peers.values():
+                config.add_peer(peer)
+
+            device.set_config(config)
+            return 0
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 1
 
 
 def syncconf(args: argparse.Namespace) -> int:
@@ -82,7 +414,7 @@ def syncconf(args: argparse.Namespace) -> int:
     try:
         config = WireguardConfig.from_wgconfig(args.configfile)
         with closing(WireguardDevice.get(args.interface)) as device:
-            device.set_config(config)
+            device.sync_config(config)
             return 0
     except RuntimeError as exc:
         print(exc, file=sys.stderr)
@@ -107,7 +439,6 @@ def genkey(_args: argparse.Namespace) -> int:
 def genpsk(_args: argparse.Namespace) -> int:
     """Generate a new preshared key and write it to stdout."""
     _check_stdout()
-    # generate a key without the curve25519 key value clamping
     random_data = token_bytes(32)
     preshared_key = WireguardKey(random_data)
     print(preshared_key)
@@ -129,14 +460,43 @@ def strip(args: argparse.Namespace) -> int:
     return 0
 
 
+def up(args: argparse.Namespace) -> int:
+    """Create and configure a WireGuard interface from a config file."""
+    from .wg_quick import WgQuickError, up as wg_up
+
+    try:
+        wg_up(args.interface)
+        return 0
+    except WgQuickError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+
+def down(args: argparse.Namespace) -> int:
+    """Tear down a WireGuard interface."""
+    from .wg_quick import WgQuickError, down as wg_down
+
+    try:
+        wg_down(args.interface)
+        return 0
+    except WgQuickError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+
 def main() -> int:
-    version_str = f"wireguard-tools {version('wireguard-tools')}"
-    parser = argparse.ArgumentParser(epilog=version_str)
+    parser = argparse.ArgumentParser(prog="wg-py")
     parser.set_defaults(func=lambda _: parser.print_help())
 
     sub = parser.add_subparsers(title="Available subcommands")
     show_parser = sub.add_parser("show", help=show.__doc__, description=show.__doc__)
     show_parser.add_argument("interface", nargs="?")
+    show_parser.add_argument(
+        "field",
+        nargs="?",
+        choices=SHOW_FIELDS,
+        default=None,
+    )
     show_parser.set_defaults(func=show)
 
     showconf_parser = sub.add_parser(
@@ -148,6 +508,7 @@ def main() -> int:
     showconf_parser.set_defaults(func=showconf)
 
     set__parser = sub.add_parser("set", help=set_.__doc__, description=set_.__doc__)
+    set__parser.add_argument("remaining", nargs=argparse.REMAINDER)
     set__parser.set_defaults(func=set_)
 
     setconf_parser = sub.add_parser(
@@ -198,7 +559,6 @@ def main() -> int:
     )
     pubkey_parser.set_defaults(func=pubkey)
 
-    # from wg-quick
     strip_parser = sub.add_parser(
         "strip",
         help=strip.__doc__,
@@ -206,6 +566,15 @@ def main() -> int:
     )
     strip_parser.add_argument("configfile", type=argparse.FileType("r"))
     strip_parser.set_defaults(func=strip)
+
+    # wg-quick commands
+    up_parser = sub.add_parser("up", help=up.__doc__, description=up.__doc__)
+    up_parser.add_argument("interface")
+    up_parser.set_defaults(func=up)
+
+    down_parser = sub.add_parser("down", help=down.__doc__, description=down.__doc__)
+    down_parser.add_argument("interface")
+    down_parser.set_defaults(func=down)
 
     args = parser.parse_args()
     result: int = args.func(args)

--- a/src/wireguard_tools/cli.py
+++ b/src/wireguard_tools/cli.py
@@ -16,7 +16,12 @@ from secrets import token_bytes
 from stat import S_IRWXO, S_ISREG
 from typing import Any, Iterable
 
-from .wireguard_config import WireguardConfig, WireguardPeer, _parse_endpoint
+from .wireguard_config import (
+    WireguardConfig,
+    WireguardPeer,
+    _parse_endpoint,
+    _split_comma_list,
+)
 from .wireguard_device import WireguardDevice
 from .wireguard_key import WireguardKey
 
@@ -157,11 +162,35 @@ def _show_field(
             print(f"{pfx}{peer.public_key}\t{rx}\t{tx}")
 
 
+def _resolve_show_args(
+    show_args: list[str],
+) -> tuple[str | None, str | None]:
+    """Resolve `wg show` positional arguments into (interface, field)."""
+    if len(show_args) > 2:
+        msg = "Usage: wg show [<interface>|all|interfaces] [<field>]"
+        raise ValueError(msg)
+    if not show_args:
+        return None, None
+    if len(show_args) == 1:
+        token = show_args[0]
+        if token in SHOW_FIELDS:
+            return None, token
+        return token, None
+    interface, field = show_args
+    if field not in SHOW_FIELDS:
+        msg = f"Unknown field: {field}"
+        raise ValueError(msg)
+    return interface, field
+
+
 def show(args: argparse.Namespace) -> int:
     """Show the current configuration and device information."""
     hide_keys = os.environ.get("WG_HIDE_KEYS", "always") != "never"
-    interface = args.interface
-    field = getattr(args, "field", None)
+    try:
+        interface, field = _resolve_show_args(getattr(args, "show_args", []))
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
 
     if interface == "interfaces":
         try:
@@ -290,7 +319,7 @@ def _parse_set_args(
                 current_peer["allowed_ips"] = []
                 current_peer["replace_allowed_ips"] = True
             else:
-                entries = [e.strip() for e in raw.split(",")]
+                entries = _split_comma_list(raw)
                 has_prefix = any(e.startswith(("+", "-")) for e in entries if e)
                 if has_prefix:
                     add_ips: list[Any] = []
@@ -490,13 +519,7 @@ def main() -> int:
 
     sub = parser.add_subparsers(title="Available subcommands")
     show_parser = sub.add_parser("show", help=show.__doc__, description=show.__doc__)
-    show_parser.add_argument("interface", nargs="?")
-    show_parser.add_argument(
-        "field",
-        nargs="?",
-        choices=SHOW_FIELDS,
-        default=None,
-    )
+    show_parser.add_argument("show_args", nargs="*")
     show_parser.set_defaults(func=show)
 
     showconf_parser = sub.add_parser(

--- a/src/wireguard_tools/curve25519.py
+++ b/src/wireguard_tools/curve25519.py
@@ -54,7 +54,21 @@ _A = 486662
 
 
 def _point_add(point_n: Point, point_m: Point, point_diff: Point) -> Point:
-    """Given the projection of two points and their difference, return their sum."""
+    """Compute the sum of two points given their difference (Montgomery ladder).
+
+    Perform differential addition on the Montgomery curve using projective
+    coordinates.  All arithmetic is reduced modulo :data:`P`.
+
+    :param point_n: First point as *(x, z)* in projective coordinates.
+    :type point_n: Point
+    :param point_m: Second point as *(x, z)* in projective coordinates.
+    :type point_m: Point
+    :param point_diff: The known difference *point_n − point_m* in
+        projective coordinates.
+    :type point_diff: Point
+    :returns: The sum *point_n + point_m* in projective coordinates.
+    :rtype: Point
+    """
     xn, zn = point_n
     xm, zm = point_m
     x_diff, z_diff = point_diff
@@ -64,7 +78,15 @@ def _point_add(point_n: Point, point_m: Point, point_diff: Point) -> Point:
 
 
 def _point_double(point_n: Point) -> Point:
-    """Double a point provided in projective coordinates."""
+    """Double a point on the Montgomery curve in projective coordinates.
+
+    All arithmetic is reduced modulo :data:`P`.
+
+    :param point_n: The point to double as *(x, z)*.
+    :type point_n: Point
+    :returns: The doubled point *2 · point_n* as *(x, z)*.
+    :rtype: Point
+    """
     xn, zn = point_n
     xn2 = xn**2
     zn2 = zn**2
@@ -75,14 +97,39 @@ def _point_double(point_n: Point) -> Point:
 
 
 def _const_time_swap(a: Point, b: Point, *, swap: bool) -> tuple[Point, Point]:
-    """Swap two values in constant time."""
+    """Conditionally swap two points in (approximately) constant time.
+
+    Uses tuple indexing rather than a branch to reduce timing
+    side-channels, though Python's big-integer arithmetic elsewhere in
+    this module is **not** constant-time — see the module-level warning.
+
+    :param a: First point.
+    :type a: Point
+    :param b: Second point.
+    :type b: Point
+    :param swap: If ``True``, return ``(b, a)``; otherwise ``(a, b)``.
+    :type swap: bool
+    :returns: The (possibly swapped) pair.
+    :rtype: tuple[Point, Point]
+    """
     index = int(swap) * 2
     temp = (a, b, b, a)
     return temp[index], temp[index + 1]
 
 
 def _raw_curve25519(base: int, n: int) -> int:
-    """Raise the point base to the power n."""
+    """Perform a Montgomery-ladder scalar multiplication on Curve25519.
+
+    Compute *n · P* where *P* is the point whose *u*-coordinate is
+    *base*, iterating from the most-significant bit downward.
+
+    :param base: The *u*-coordinate of the base point (integer mod *P*).
+    :type base: int
+    :param n: The scalar (already clamped).
+    :type n: int
+    :returns: The *u*-coordinate of the resulting point.
+    :rtype: int
+    """
     zero = (1, 0)
     one = (base, 1)
     mP, m1P = zero, one
@@ -99,7 +146,14 @@ def _raw_curve25519(base: int, n: int) -> int:
 
 
 def _unpack_number(s: bytes) -> int:
-    """Unpack 32 bytes to a 256 bit value."""
+    """Unpack a 32-byte little-endian byte string into a 256-bit integer.
+
+    :param s: Exactly 32 bytes of data.
+    :type s: bytes
+    :returns: The decoded unsigned integer.
+    :rtype: int
+    :raises ValueError: If *s* is not exactly 32 bytes long.
+    """
     if len(s) != RAW_KEY_LENGTH:
         msg = "Curve25519 values must be 32 bytes"
         raise ValueError(msg)
@@ -107,11 +161,27 @@ def _unpack_number(s: bytes) -> int:
 
 
 def _pack_number(n: int) -> bytes:
-    """Pack a value into 32 bytes."""
+    """Pack a 256-bit integer into a 32-byte little-endian byte string.
+
+    :param n: The integer to encode (must fit in 32 bytes).
+    :type n: int
+    :returns: A 32-byte ``bytes`` object.
+    :rtype: bytes
+    """
     return n.to_bytes(RAW_KEY_LENGTH, "little")
 
 
 def _fix_base_point(n: int) -> int:
+    """Mask a base-point *u*-coordinate per :rfc:`7748` §5.
+
+    Clear the most-significant bit of the final byte so that the
+    *u*-coordinate is reduced to 255 bits as required by the protocol.
+
+    :param n: Raw decoded integer from a 32-byte public key.
+    :type n: int
+    :returns: The masked *u*-coordinate.
+    :rtype: int
+    """
     # RFC7748 section 5
     # u-coordinates are ... encoded as an array of bytes ... When receiving
     # such an array, implementations of X25519 MUST mask the most significant
@@ -121,7 +191,19 @@ def _fix_base_point(n: int) -> int:
 
 
 def _fix_secret(n: int) -> int:
-    """Mask a value to be an acceptable exponent."""
+    """Clamp a raw integer into a valid Curve25519 private scalar.
+
+    Apply the three clamping operations defined in :rfc:`7748` §5:
+
+    1. Clear the three lowest bits (ensures the scalar is a multiple of 8).
+    2. Clear bit 255 (the most-significant bit of the final byte).
+    3. Set bit 254 (ensures a fixed position for the high bit).
+
+    :param n: The raw 256-bit integer to clamp.
+    :type n: int
+    :returns: The clamped scalar.
+    :rtype: int
+    """
     n &= ~7
     n &= ~(128 << 8 * 31)
     n |= 64 << 8 * 31
@@ -129,45 +211,163 @@ def _fix_secret(n: int) -> int:
 
 
 def curve25519(base_point_raw: bytes, secret_raw: bytes) -> bytes:
-    """Raise the base point to a given power."""
+    """Perform an X25519 Diffie-Hellman function on raw byte inputs.
+
+    Decode and clamp both the base point and the secret, execute the
+    Montgomery-ladder scalar multiplication, and return the result as a
+    32-byte little-endian byte string.
+
+    :param base_point_raw: 32-byte encoding of the peer's public
+        *u*-coordinate.
+    :type base_point_raw: bytes
+    :param secret_raw: 32-byte encoding of the local private scalar.
+    :type secret_raw: bytes
+    :returns: The 32-byte shared secret.
+    :rtype: bytes
+    :raises ValueError: If either input is not exactly 32 bytes.
+    """
     base_point = _fix_base_point(_unpack_number(base_point_raw))
     secret = _fix_secret(_unpack_number(secret_raw))
     return _pack_number(_raw_curve25519(base_point, secret))
 
 
 def curve25519_base(secret_raw: bytes) -> bytes:
-    """Raise the generator point to a given power."""
+    """Derive a Curve25519 public key from a raw private scalar.
+
+    Equivalent to ``curve25519(generator, secret_raw)`` where the
+    generator has *u*-coordinate 9.
+
+    :param secret_raw: 32-byte encoding of the private scalar.
+    :type secret_raw: bytes
+    :returns: The 32-byte public key.
+    :rtype: bytes
+    :raises ValueError: If *secret_raw* is not exactly 32 bytes.
+    """
     secret = _fix_secret(_unpack_number(secret_raw))
     return _pack_number(_raw_curve25519(9, secret))
 
 
 class X25519PublicKey:
+    """An X25519 public key (a point on Curve25519).
+
+    This class provides an API compatible with
+    :class:`cryptography.hazmat.primitives.asymmetric.x25519.X25519PublicKey`
+    so it can be used as a drop-in pure-Python replacement.
+
+    :param x: The *u*-coordinate of the public point (already masked).
+    :type x: int
+    """
+
     def __init__(self, x: int) -> None:
+        """Initialise with a pre-masked *u*-coordinate integer.
+
+        Callers should normally use :meth:`from_public_bytes` instead of
+        invoking the constructor directly.
+
+        :param x: Masked *u*-coordinate.
+        :type x: int
+        """
         self.x = x
 
     @classmethod
     def from_public_bytes(cls, data: bytes) -> X25519PublicKey:
+        """Construct a public key from its 32-byte encoding.
+
+        The most-significant bit of the final byte is cleared per
+        :rfc:`7748` §5 before storing.
+
+        :param data: 32-byte raw public key.
+        :type data: bytes
+        :returns: The decoded public key.
+        :rtype: X25519PublicKey
+        :raises ValueError: If *data* is not exactly 32 bytes.
+        """
         return cls(_fix_base_point(_unpack_number(data)))
 
     def public_bytes(self) -> bytes:
+        """Serialise the public key to a 32-byte little-endian byte string.
+
+        :returns: The encoded public key.
+        :rtype: bytes
+        """
         return _pack_number(self.x)
 
 
 class X25519PrivateKey:
+    """An X25519 private key (a clamped Curve25519 scalar).
+
+    This class provides an API compatible with
+    :class:`cryptography.hazmat.primitives.asymmetric.x25519.X25519PrivateKey`
+    so it can be used as a drop-in pure-Python replacement.
+
+    .. warning::
+
+       The underlying arithmetic uses Python's arbitrary-precision
+       integers and is **not** constant-time.  See the module-level
+       timing warning before using this in security-sensitive contexts.
+
+    :param a: The clamped private scalar.
+    :type a: int
+    """
+
     def __init__(self, a: int) -> None:
+        """Initialise with an already-clamped scalar.
+
+        Callers should normally use :meth:`from_private_bytes` which
+        applies the clamping automatically.
+
+        :param a: Clamped private scalar.
+        :type a: int
+        """
         self.a = a
 
     @classmethod
     def from_private_bytes(cls, data: bytes) -> X25519PrivateKey:
+        """Construct a private key from its 32-byte encoding.
+
+        The raw bytes are decoded as a little-endian integer and then
+        clamped via :func:`_fix_secret` to produce a valid Curve25519
+        scalar.
+
+        :param data: 32-byte raw private key material.
+        :type data: bytes
+        :returns: The decoded and clamped private key.
+        :rtype: X25519PrivateKey
+        :raises ValueError: If *data* is not exactly 32 bytes.
+        """
         return cls(_fix_secret(_unpack_number(data)))
 
     def private_bytes(self) -> bytes:
+        """Serialise the private scalar to a 32-byte little-endian byte string.
+
+        :returns: The encoded private key.
+        :rtype: bytes
+        """
         return _pack_number(self.a)
 
     def public_key(self) -> bytes:
+        """Derive the corresponding public key.
+
+        Multiply the Curve25519 base point (*u* = 9) by the private
+        scalar and return the result as a 32-byte encoding.
+
+        :returns: The 32-byte public key.
+        :rtype: bytes
+        """
         return _pack_number(_raw_curve25519(9, self.a))
 
     def exchange(self, peer_public_key: X25519PublicKey | bytes) -> bytes:
+        """Perform an X25519 Diffie-Hellman key exchange.
+
+        Multiply *peer_public_key* by the private scalar and return the
+        shared secret.  If *peer_public_key* is raw ``bytes`` it is
+        first decoded via :meth:`X25519PublicKey.from_public_bytes`.
+
+        :param peer_public_key: The peer's public key.
+        :type peer_public_key: X25519PublicKey | bytes
+        :returns: The 32-byte shared secret.
+        :rtype: bytes
+        """
         if isinstance(peer_public_key, bytes):
             peer_public_key = X25519PublicKey.from_public_bytes(peer_public_key)
         return _pack_number(_raw_curve25519(peer_public_key.x, self.a))

--- a/src/wireguard_tools/daemon.py
+++ b/src/wireguard_tools/daemon.py
@@ -5,6 +5,30 @@
 # SPDX-License-Identifier: MIT
 #
 
+"""Privileged WireGuard management daemon exposing a JSON-over-Unix-socket API.
+
+The daemon listens on a ``SOCK_STREAM`` Unix socket (default
+``/var/run/wg-daemon.sock``) and accepts one JSON request per connection.
+
+**Protocol:**
+
+*  **Request** — a single JSON line::
+
+       {"cmd": "<command>", "args": {<command-specific fields>}}
+
+*  **Response** — a single JSON line::
+
+       {"ok": true, "data": ...}   // on success
+       {"ok": false, "error": "..."}  // on failure
+
+Supported commands: ``up``, ``down``, ``show``, ``set_peer``,
+``remove_peer``, ``list_devices``.
+
+Socket ownership is configurable via ``--group`` (or ``WG_DAEMON_GROUP``)
+so that unprivileged users in the designated group can issue requests
+without requiring root.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -32,6 +56,16 @@ logger = logging.getLogger("wg-daemon")
 
 
 def _cmd_up(args: dict[str, Any]) -> dict[str, Any]:
+    """Bring a WireGuard interface up.
+
+    Delegates to :func:`~.wg_quick.up` which configures addresses, routes,
+    and the WireGuard tunnel.
+
+    :param args: Must contain ``"interface"`` (str) — the interface name.
+    :returns: ``{"ok": True}`` on success, or ``{"ok": False, "error": ...}``
+        on failure.
+    :rtype: dict[str, Any]
+    """
     interface = args.get("interface")
     if not interface:
         return {"ok": False, "error": "Missing required argument: interface"}
@@ -43,6 +77,16 @@ def _cmd_up(args: dict[str, Any]) -> dict[str, Any]:
 
 
 def _cmd_down(args: dict[str, Any]) -> dict[str, Any]:
+    """Tear down a WireGuard interface.
+
+    Delegates to :func:`~.wg_quick.down` which removes addresses, routes,
+    and the tunnel.
+
+    :param args: Must contain ``"interface"`` (str) — the interface name.
+    :returns: ``{"ok": True}`` on success, or ``{"ok": False, "error": ...}``
+        on failure.
+    :rtype: dict[str, Any]
+    """
     interface = args.get("interface")
     if not interface:
         return {"ok": False, "error": "Missing required argument: interface"}
@@ -54,6 +98,17 @@ def _cmd_down(args: dict[str, Any]) -> dict[str, Any]:
 
 
 def _cmd_show(args: dict[str, Any]) -> dict[str, Any]:
+    """Return the current configuration of a WireGuard interface.
+
+    Open the device, call :meth:`~.wireguard_device.WireguardDevice.get_config`,
+    and serialise the result via
+    :meth:`~.wireguard_config.WireguardConfig.asdict`.
+
+    :param args: Must contain ``"interface"`` (str) — the interface name.
+    :returns: ``{"ok": True, "data": <config dict>}`` on success, or
+        ``{"ok": False, "error": ...}`` on failure.
+    :rtype: dict[str, Any]
+    """
     interface = args.get("interface")
     if not interface:
         return {"ok": False, "error": "Missing required argument: interface"}
@@ -66,6 +121,22 @@ def _cmd_show(args: dict[str, Any]) -> dict[str, Any]:
 
 
 def _cmd_set_peer(args: dict[str, Any]) -> dict[str, Any]:
+    """Add or update a peer on a WireGuard interface.
+
+    Construct a :class:`~.wireguard_config.WireguardPeer` from *args*, merge
+    it into the current running configuration via
+    :meth:`~.wireguard_config.WireguardConfig.add_peer`, and apply the result
+    with :meth:`~.wireguard_device.WireguardDevice.set_config`.
+
+    :param args: Required keys: ``"interface"`` (str), ``"public_key"``
+        (str, base64).  Optional keys: ``"allowed_ips"`` (list of CIDR
+        strings), ``"endpoint_host"`` (str), ``"endpoint_port"`` (int/str),
+        ``"preshared_key"`` (str, base64), ``"persistent_keepalive"``
+        (int/str).
+    :returns: ``{"ok": True}`` on success, or ``{"ok": False, "error": ...}``
+        on failure.
+    :rtype: dict[str, Any]
+    """
     interface = args.get("interface")
     public_key = args.get("public_key")
     if not interface or not public_key:
@@ -100,6 +171,18 @@ def _cmd_set_peer(args: dict[str, Any]) -> dict[str, Any]:
 
 
 def _cmd_remove_peer(args: dict[str, Any]) -> dict[str, Any]:
+    """Remove a peer from a WireGuard interface.
+
+    Look up the peer by its public key in the running configuration,
+    delete it via :meth:`~.wireguard_config.WireguardConfig.del_peer`,
+    and push the updated configuration to the device.
+
+    :param args: Required keys: ``"interface"`` (str), ``"public_key"``
+        (str, base64).
+    :returns: ``{"ok": True}`` on success, or ``{"ok": False, "error": ...}``
+        when the peer is not found or another error occurs.
+    :rtype: dict[str, Any]
+    """
     interface = args.get("interface")
     public_key = args.get("public_key")
     if not interface or not public_key:
@@ -118,6 +201,17 @@ def _cmd_remove_peer(args: dict[str, Any]) -> dict[str, Any]:
 
 
 def _cmd_list_devices(_args: dict[str, Any]) -> dict[str, Any]:
+    """List all active WireGuard interface names.
+
+    Discovers interfaces via
+    :meth:`~.wireguard_device.WireguardDevice.list` and returns their
+    names.
+
+    :param _args: Ignored (no arguments required for this command).
+    :returns: ``{"ok": True, "data": [<interface names>]}`` on success, or
+        ``{"ok": False, "error": ...}`` on failure.
+    :rtype: dict[str, Any]
+    """
     try:
         devices = [d.interface for d in WireguardDevice.list()]
         return {"ok": True, "data": devices}
@@ -136,9 +230,25 @@ COMMANDS = {
 
 
 class DaemonHandler(socketserver.StreamRequestHandler):
-    """Handle one JSON-line request per connection."""
+    """Handle a single JSON-line request per connection.
+
+    Each accepted connection is expected to send exactly **one** JSON line
+    (see the module docstring for the protocol).  The handler reads the
+    line, dispatches it to the matching ``_cmd_*`` function from
+    :data:`COMMANDS`, and writes a single JSON-line response before closing
+    the connection.
+
+    Malformed JSON or an unrecognised ``cmd`` value results in an
+    ``{"ok": false, "error": "..."}`` response — the connection is never
+    left hanging.
+    """
 
     def handle(self) -> None:
+        """Read one JSON request, dispatch it, and write the response.
+
+        :returns: Nothing; the response is written directly to the socket.
+        :rtype: None
+        """
         try:
             raw = self.rfile.readline()
             if not raw:
@@ -161,18 +271,48 @@ class DaemonHandler(socketserver.StreamRequestHandler):
         self._send(response)
 
     def _send(self, response: dict[str, Any]) -> None:
+        """Serialise *response* as a JSON line and flush it to the client.
+
+        :param response: Dictionary to serialise.  By convention contains at
+            least an ``"ok"`` boolean key.
+        """
         data = json.dumps(response) + "\n"
         self.wfile.write(data.encode("utf-8"))
         self.wfile.flush()
 
 
 class ThreadedUnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    """Thread-per-connection Unix-domain stream server.
+
+    Inherits :class:`~socketserver.ThreadingMixIn` to spawn a daemon thread
+    for each accepted connection and :class:`~socketserver.UnixStreamServer`
+    for ``AF_UNIX`` ``SOCK_STREAM`` transport.
+
+    :cvar daemon_threads: ``True`` — worker threads do not prevent process
+        exit.
+    :cvar allow_reuse_address: ``True`` — allows rebinding after unclean
+        shutdown.
+
+    The socket file is created by the standard library; callers should set
+    ownership and permissions via :func:`_set_socket_permissions` immediately
+    after construction.
+    """
+
     daemon_threads = True
     allow_reuse_address = True
 
 
 def _set_socket_permissions(socket_path: str, group: str | None) -> None:
-    """Set ownership and permissions on the daemon socket."""
+    """Set ownership and permissions on the daemon socket.
+
+    If *group* is provided, the socket file's group is changed via
+    :func:`os.chown`; if the group name cannot be resolved a warning is
+    logged but execution continues.  Permissions are always set to
+    :data:`SOCKET_PERMISSIONS` (``0o660``).
+
+    :param socket_path: Filesystem path of the Unix socket.
+    :param group: Optional Unix group name to assign to the socket file.
+    """
     if group:
         try:
             gid = grp.getgrnam(group).gr_gid
@@ -186,7 +326,20 @@ def serve(
     socket_path: str = DEFAULT_SOCKET_PATH,
     group: str | None = None,
 ) -> None:
-    """Start the daemon and serve requests until interrupted."""
+    """Start the daemon and block, serving requests until interrupted.
+
+    Create a :class:`ThreadedUnixServer` bound to *socket_path*, install
+    ``SIGTERM`` / ``SIGINT`` handlers that trigger a graceful shutdown, and
+    enter :meth:`~socketserver.BaseServer.serve_forever`.  On exit the
+    socket file is unlinked.
+
+    If *socket_path* already exists (e.g. from a previous unclean shutdown)
+    it is removed before binding.
+
+    :param socket_path: Filesystem path for the listening Unix socket.
+    :param group: Optional Unix group name passed to
+        :func:`_set_socket_permissions`.
+    """
     path = Path(socket_path)
     if path.exists():
         path.unlink()
@@ -213,6 +366,23 @@ def serve(
 
 
 def main() -> None:
+    """Parse CLI arguments and start the daemon.
+
+    Accepted arguments:
+
+    ``--socket``
+        Path for the Unix socket (env: ``WG_DAEMON_SOCKET``, default
+        ``/var/run/wg-daemon.sock``).
+    ``--group``
+        Group name for socket ownership (env: ``WG_DAEMON_GROUP``, default
+        ``wireguard``).
+    ``--foreground``
+        Run in foreground (default; intended for systemd management).
+    ``-v`` / ``--verbose``
+        Enable ``DEBUG``-level logging.
+
+    Logging is emitted to *stderr* in a timestamped format.
+    """
     parser = argparse.ArgumentParser(description="WireGuard Tools Daemon")
     parser.add_argument(
         "--socket",

--- a/src/wireguard_tools/daemon.py
+++ b/src/wireguard_tools/daemon.py
@@ -1,0 +1,250 @@
+#
+# WireGuard Tools Daemon -- privileged helper over a Unix socket
+#
+# Copyright (c) 2024 Richard Dawson
+# SPDX-License-Identifier: MIT
+#
+
+from __future__ import annotations
+
+import argparse
+import grp
+import json
+import logging
+import os
+import signal
+import socketserver
+import sys
+from contextlib import closing
+from ipaddress import ip_interface
+from pathlib import Path
+from typing import Any
+
+from .wg_quick import down, up
+from .wireguard_config import WireguardConfig, WireguardPeer
+from .wireguard_device import WireguardDevice
+from .wireguard_key import WireguardKey
+
+DEFAULT_SOCKET_PATH = "/var/run/wg-daemon.sock"
+SOCKET_PERMISSIONS = 0o660
+
+logger = logging.getLogger("wg-daemon")
+
+
+def _cmd_up(args: dict[str, Any]) -> dict[str, Any]:
+    interface = args.get("interface")
+    if not interface:
+        return {"ok": False, "error": "Missing required argument: interface"}
+    try:
+        up(interface)
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True}
+
+
+def _cmd_down(args: dict[str, Any]) -> dict[str, Any]:
+    interface = args.get("interface")
+    if not interface:
+        return {"ok": False, "error": "Missing required argument: interface"}
+    try:
+        down(interface)
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True}
+
+
+def _cmd_show(args: dict[str, Any]) -> dict[str, Any]:
+    interface = args.get("interface")
+    if not interface:
+        return {"ok": False, "error": "Missing required argument: interface"}
+    try:
+        with closing(WireguardDevice.get(interface)) as device:
+            config = device.get_config()
+            return {"ok": True, "data": config.asdict()}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+def _cmd_set_peer(args: dict[str, Any]) -> dict[str, Any]:
+    interface = args.get("interface")
+    public_key = args.get("public_key")
+    if not interface or not public_key:
+        return {"ok": False, "error": "Missing required arguments: interface, public_key"}
+    try:
+        key = WireguardKey(public_key)
+        peer_kwargs: dict[str, Any] = {"public_key": key}
+
+        if "allowed_ips" in args:
+            peer_kwargs["allowed_ips"] = [
+                ip_interface(ip) for ip in args["allowed_ips"]
+            ]
+        if "endpoint_host" in args:
+            peer_kwargs["endpoint_host"] = args["endpoint_host"]
+        if "endpoint_port" in args:
+            peer_kwargs["endpoint_port"] = int(args["endpoint_port"])
+        if "preshared_key" in args:
+            peer_kwargs["preshared_key"] = WireguardKey(args["preshared_key"])
+        if "persistent_keepalive" in args:
+            peer_kwargs["persistent_keepalive"] = int(args["persistent_keepalive"])
+
+        peer = WireguardPeer(**peer_kwargs)
+
+        with closing(WireguardDevice.get(interface)) as device:
+            current = device.get_config()
+            current.add_peer(peer)
+            device.set_config(current)
+
+        return {"ok": True}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+def _cmd_remove_peer(args: dict[str, Any]) -> dict[str, Any]:
+    interface = args.get("interface")
+    public_key = args.get("public_key")
+    if not interface or not public_key:
+        return {"ok": False, "error": "Missing required arguments: interface, public_key"}
+    try:
+        key = WireguardKey(public_key)
+        with closing(WireguardDevice.get(interface)) as device:
+            current = device.get_config()
+            current.del_peer(key)
+            device.set_config(current)
+        return {"ok": True}
+    except KeyError:
+        return {"ok": False, "error": f"Peer {public_key} not found on {interface}"}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+def _cmd_list_devices(_args: dict[str, Any]) -> dict[str, Any]:
+    try:
+        devices = [d.interface for d in WireguardDevice.list()]
+        return {"ok": True, "data": devices}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+COMMANDS = {
+    "up": _cmd_up,
+    "down": _cmd_down,
+    "show": _cmd_show,
+    "set_peer": _cmd_set_peer,
+    "remove_peer": _cmd_remove_peer,
+    "list_devices": _cmd_list_devices,
+}
+
+
+class DaemonHandler(socketserver.StreamRequestHandler):
+    """Handle one JSON-line request per connection."""
+
+    def handle(self) -> None:
+        try:
+            raw = self.rfile.readline()
+            if not raw:
+                return
+            request = json.loads(raw.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            response = {"ok": False, "error": f"Invalid request: {exc}"}
+            self._send(response)
+            return
+
+        cmd = request.get("cmd")
+        args = request.get("args", {})
+
+        if cmd not in COMMANDS:
+            response = {"ok": False, "error": f"Unknown command: {cmd}"}
+        else:
+            logger.info("cmd=%s args=%s", cmd, args)
+            response = COMMANDS[cmd](args)
+
+        self._send(response)
+
+    def _send(self, response: dict[str, Any]) -> None:
+        data = json.dumps(response) + "\n"
+        self.wfile.write(data.encode("utf-8"))
+        self.wfile.flush()
+
+
+class ThreadedUnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def _set_socket_permissions(socket_path: str, group: str | None) -> None:
+    """Set ownership and permissions on the daemon socket."""
+    if group:
+        try:
+            gid = grp.getgrnam(group).gr_gid
+            os.chown(socket_path, -1, gid)
+        except KeyError:
+            logger.warning("Group %r not found; socket group unchanged", group)
+    os.chmod(socket_path, SOCKET_PERMISSIONS)
+
+
+def serve(
+    socket_path: str = DEFAULT_SOCKET_PATH,
+    group: str | None = None,
+) -> None:
+    """Start the daemon and serve requests until interrupted."""
+    path = Path(socket_path)
+    if path.exists():
+        path.unlink()
+
+    server = ThreadedUnixServer(socket_path, DaemonHandler)
+
+    _set_socket_permissions(socket_path, group)
+    logger.info("Listening on %s", socket_path)
+
+    def _shutdown(signum: int, _frame: Any) -> None:
+        logger.info("Received signal %d, shutting down", signum)
+        server.shutdown()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+        if path.exists():
+            path.unlink()
+        logger.info("Daemon stopped")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="WireGuard Tools Daemon")
+    parser.add_argument(
+        "--socket",
+        default=os.environ.get("WG_DAEMON_SOCKET", DEFAULT_SOCKET_PATH),
+        help="Unix socket path (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--group",
+        default=os.environ.get("WG_DAEMON_GROUP", "wireguard"),
+        help="Group for socket ownership (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--foreground",
+        action="store_true",
+        default=True,
+        help="Run in foreground (default; systemd manages lifecycle)",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+
+    serve(socket_path=args.socket, group=args.group)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/wireguard_tools/daemon_client.py
+++ b/src/wireguard_tools/daemon_client.py
@@ -1,0 +1,107 @@
+#
+# WireGuard Daemon Client -- IPC over a Unix socket
+#
+# Copyright (c) 2024 Richard Dawson
+# SPDX-License-Identifier: MIT
+#
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from typing import Any
+
+DEFAULT_SOCKET_PATH = "/var/run/wg-daemon.sock"
+
+
+class DaemonError(RuntimeError):
+    """Raised when the daemon returns an error response."""
+
+
+class WgDaemonClient:
+    """Thin client for the wg-daemon Unix socket protocol.
+
+    Each method connects, sends a single JSON request, reads the JSON
+    response, and disconnects.  This keeps the protocol stateless and
+    avoids holding sockets open.
+    """
+
+    def __init__(
+        self,
+        socket_path: str | None = None,
+    ) -> None:
+        self.socket_path = (
+            socket_path
+            or os.environ.get("WG_DAEMON_SOCKET")
+            or DEFAULT_SOCKET_PATH
+        )
+
+    def _request(self, cmd: str, args: dict[str, Any] | None = None) -> Any:
+        """Send *cmd* with *args* and return the ``data`` field on success."""
+        payload = {"cmd": cmd, "args": args or {}}
+        raw = json.dumps(payload) + "\n"
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.connect(self.socket_path)
+            sock.sendall(raw.encode("utf-8"))
+            sock.shutdown(socket.SHUT_WR)
+
+            chunks: list[bytes] = []
+            while True:
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        finally:
+            sock.close()
+
+        response = json.loads(b"".join(chunks).decode("utf-8"))
+        if not response.get("ok"):
+            raise DaemonError(response.get("error", "Unknown daemon error"))
+        return response.get("data")
+
+    def up(self, interface: str) -> None:
+        self._request("up", {"interface": interface})
+
+    def down(self, interface: str) -> None:
+        self._request("down", {"interface": interface})
+
+    def show(self, interface: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request("show", {"interface": interface})
+        return data
+
+    def set_peer(
+        self,
+        interface: str,
+        public_key: str,
+        *,
+        allowed_ips: list[str] | None = None,
+        endpoint_host: str | None = None,
+        endpoint_port: int | None = None,
+        preshared_key: str | None = None,
+        persistent_keepalive: int | None = None,
+    ) -> None:
+        args: dict[str, Any] = {
+            "interface": interface,
+            "public_key": public_key,
+        }
+        if allowed_ips is not None:
+            args["allowed_ips"] = allowed_ips
+        if endpoint_host is not None:
+            args["endpoint_host"] = endpoint_host
+        if endpoint_port is not None:
+            args["endpoint_port"] = endpoint_port
+        if preshared_key is not None:
+            args["preshared_key"] = preshared_key
+        if persistent_keepalive is not None:
+            args["persistent_keepalive"] = persistent_keepalive
+        self._request("set_peer", args)
+
+    def remove_peer(self, interface: str, public_key: str) -> None:
+        self._request("remove_peer", {"interface": interface, "public_key": public_key})
+
+    def list_devices(self) -> list[str]:
+        data: list[str] = self._request("list_devices")
+        return data

--- a/src/wireguard_tools/daemon_client.py
+++ b/src/wireguard_tools/daemon_client.py
@@ -4,6 +4,20 @@
 # Copyright (c) 2024 Richard Dawson
 # SPDX-License-Identifier: MIT
 #
+"""Client for the ``wg-daemon`` Unix-socket JSON-line protocol.
+
+This module provides :class:`WgDaemonClient`, a thin synchronous client
+that communicates with a privileged WireGuard daemon over a Unix-domain
+stream socket.  Each public method opens a fresh connection, sends one
+JSON request terminated by a newline, shuts down the write half of the
+socket, reads the full JSON response, and closes the connection.  This
+keeps the protocol entirely stateless.
+
+The daemon is expected to reply with a JSON object containing at least
+an ``ok`` boolean field.  On success the ``data`` field (if present) is
+returned; on failure a :class:`DaemonError` is raised with the
+``error`` message.
+"""
 
 from __future__ import annotations
 
@@ -16,21 +30,44 @@ DEFAULT_SOCKET_PATH = "/var/run/wg-daemon.sock"
 
 
 class DaemonError(RuntimeError):
-    """Raised when the daemon returns an error response."""
+    """Raised when the daemon returns a non-OK response.
+
+    The exception message is taken from the ``error`` field of the JSON
+    response, or falls back to ``"Unknown daemon error"`` when the field
+    is absent.
+    """
 
 
 class WgDaemonClient:
-    """Thin client for the wg-daemon Unix socket protocol.
+    """Thin synchronous client for the ``wg-daemon`` Unix-socket protocol.
 
-    Each method connects, sends a single JSON request, reads the JSON
-    response, and disconnects.  This keeps the protocol stateless and
-    avoids holding sockets open.
+    Each public method opens a fresh ``AF_UNIX`` stream connection, sends
+    a single JSON-line request, and reads the full JSON response before
+    closing the socket.  This makes every call stateless and avoids the
+    need for connection pooling or keep-alive management.
+
+    The socket path is resolved in the following order:
+
+    1. The *socket_path* constructor argument (if not ``None``).
+    2. The ``WG_DAEMON_SOCKET`` environment variable.
+    3. :data:`DEFAULT_SOCKET_PATH` (``/var/run/wg-daemon.sock``).
+
+    :param socket_path: Explicit path to the daemon's Unix socket, or
+        ``None`` to auto-detect.
+    :type socket_path: str | None
     """
 
     def __init__(
         self,
         socket_path: str | None = None,
     ) -> None:
+        """Initialise the client and resolve the socket path.
+
+        :param socket_path: Override for the daemon socket path.  When
+            ``None``, the ``WG_DAEMON_SOCKET`` environment variable is
+            tried, falling back to :data:`DEFAULT_SOCKET_PATH`.
+        :type socket_path: str | None
+        """
         self.socket_path = (
             socket_path
             or os.environ.get("WG_DAEMON_SOCKET")
@@ -38,7 +75,24 @@ class WgDaemonClient:
         )
 
     def _request(self, cmd: str, args: dict[str, Any] | None = None) -> Any:
-        """Send *cmd* with *args* and return the ``data`` field on success."""
+        """Send a single JSON-line command and return the response data.
+
+        Open a new ``AF_UNIX`` connection to :attr:`socket_path`, send a
+        JSON object of the form ``{"cmd": "<cmd>", "args": {…}}``,
+        terminate the write side, read the entire response, and parse it
+        as JSON.
+
+        :param cmd: The daemon command name (e.g. ``"up"``, ``"show"``).
+        :type cmd: str
+        :param args: Optional mapping of command arguments.
+        :type args: dict[str, Any] | None
+        :returns: The ``data`` field of the response, or ``None`` if the
+            field is absent.
+        :rtype: Any
+        :raises DaemonError: If the response ``ok`` field is falsy.
+        :raises ConnectionRefusedError: If the daemon socket is not
+            reachable.
+        """
         payload = {"cmd": cmd, "args": args or {}}
         raw = json.dumps(payload) + "\n"
 
@@ -63,12 +117,34 @@ class WgDaemonClient:
         return response.get("data")
 
     def up(self, interface: str) -> None:
+        """Bring a WireGuard interface up.
+
+        :param interface: Name of the WireGuard network interface
+            (e.g. ``"wg0"``).
+        :type interface: str
+        :raises DaemonError: If the daemon reports a failure.
+        """
         self._request("up", {"interface": interface})
 
     def down(self, interface: str) -> None:
+        """Tear down a WireGuard interface.
+
+        :param interface: Name of the WireGuard network interface.
+        :type interface: str
+        :raises DaemonError: If the daemon reports a failure.
+        """
         self._request("down", {"interface": interface})
 
     def show(self, interface: str) -> dict[str, Any]:
+        """Retrieve the current configuration and status of an interface.
+
+        :param interface: Name of the WireGuard network interface.
+        :type interface: str
+        :returns: A dictionary of interface attributes and peer
+            information as returned by the daemon.
+        :rtype: dict[str, Any]
+        :raises DaemonError: If the daemon reports a failure.
+        """
         data: dict[str, Any] = self._request("show", {"interface": interface})
         return data
 
@@ -83,6 +159,33 @@ class WgDaemonClient:
         preshared_key: str | None = None,
         persistent_keepalive: int | None = None,
     ) -> None:
+        """Add or update a peer on the given interface.
+
+        Only the parameters that are not ``None`` are forwarded to the
+        daemon; omitted parameters leave the corresponding peer setting
+        unchanged (for existing peers) or at the daemon's default (for
+        new peers).
+
+        :param interface: Name of the WireGuard network interface.
+        :type interface: str
+        :param public_key: Base64-encoded public key of the peer.
+        :type public_key: str
+        :param allowed_ips: CIDR-notation networks the peer is allowed
+            to send traffic from (e.g. ``["10.0.0.2/32"]``).
+        :type allowed_ips: list[str] | None
+        :param endpoint_host: Hostname or IP address of the peer's
+            endpoint.
+        :type endpoint_host: str | None
+        :param endpoint_port: UDP port of the peer's endpoint.
+        :type endpoint_port: int | None
+        :param preshared_key: Base64-encoded preshared key, or ``None``
+            to leave unset.
+        :type preshared_key: str | None
+        :param persistent_keepalive: Keepalive interval in seconds, or
+            ``None`` to disable.
+        :type persistent_keepalive: int | None
+        :raises DaemonError: If the daemon reports a failure.
+        """
         args: dict[str, Any] = {
             "interface": interface,
             "public_key": public_key,
@@ -100,8 +203,23 @@ class WgDaemonClient:
         self._request("set_peer", args)
 
     def remove_peer(self, interface: str, public_key: str) -> None:
+        """Remove a peer from the given interface.
+
+        :param interface: Name of the WireGuard network interface.
+        :type interface: str
+        :param public_key: Base64-encoded public key of the peer to
+            remove.
+        :type public_key: str
+        :raises DaemonError: If the daemon reports a failure.
+        """
         self._request("remove_peer", {"interface": interface, "public_key": public_key})
 
     def list_devices(self) -> list[str]:
+        """List all WireGuard interfaces known to the daemon.
+
+        :returns: A list of interface names (e.g. ``["wg0", "wg1"]``).
+        :rtype: list[str]
+        :raises DaemonError: If the daemon reports a failure.
+        """
         data: list[str] = self._request("list_devices")
         return data

--- a/src/wireguard_tools/wg_quick.py
+++ b/src/wireguard_tools/wg_quick.py
@@ -1,0 +1,413 @@
+#
+# Pure Python reimplementation of wg-quick
+#
+# Copyright (c) 2024 Richard Dawson
+# SPDX-License-Identifier: MIT
+#
+# Implements the core logic of the wg-quick(8) bash script using pyroute2
+# for netlink-based interface, address, and route management.
+#
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from contextlib import closing
+from ipaddress import IPv4Network, IPv6Network, ip_interface, ip_network
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pyroute2
+
+from .wireguard_config import WireguardConfig
+from .wireguard_device import WireguardDevice
+
+if TYPE_CHECKING:
+    from ipaddress import IPv4Interface, IPv6Interface
+
+WG_CONFIG_DIR = Path("/etc/wireguard")
+DEFAULT_TABLE = "auto"
+DEFAULT_MTU_V4 = 1420
+DEFAULT_MTU_V6 = 1420
+
+
+class WgQuickError(RuntimeError):
+    """Raised when a wg-quick operation fails."""
+
+
+def _find_config(name_or_path: str) -> tuple[str, Path]:
+    """Resolve an interface name or config path to (ifname, config_path)."""
+    p = Path(name_or_path)
+    if p.suffix == ".conf" and p.exists():
+        return p.stem, p
+    config_path = WG_CONFIG_DIR / f"{name_or_path}.conf"
+    if config_path.exists():
+        return name_or_path, config_path
+    msg = f"Configuration file not found for '{name_or_path}'"
+    raise WgQuickError(msg)
+
+
+def _run_hook(cmd: str, ifname: str) -> None:
+    """Run a PreUp/PostUp/PreDown/PostDown hook command."""
+    env = os.environ.copy()
+    env["WIREGUARD_INTERFACE"] = ifname
+    result = subprocess.run(
+        cmd,
+        shell=True,  # noqa: S602 -- hooks are inherently shell commands
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        msg = f"Hook command failed (exit {result.returncode}): {cmd}"
+        raise WgQuickError(msg)
+
+
+def _interface_exists(ifname: str) -> bool:
+    with pyroute2.IPRoute() as ipr:
+        links = ipr.link_lookup(ifname=ifname)
+        return len(links) > 0
+
+
+def _create_interface(ifname: str) -> None:
+    with pyroute2.IPRoute() as ipr:
+        ipr.link("add", ifname=ifname, kind="wireguard")
+
+
+def _delete_interface(ifname: str) -> None:
+    with pyroute2.IPRoute() as ipr:
+        idx = ipr.link_lookup(ifname=ifname)
+        if idx:
+            ipr.link("del", index=idx[0])
+
+
+def _set_link_up(ifname: str, mtu: int | None = None) -> None:
+    with pyroute2.IPRoute() as ipr:
+        idx = ipr.link_lookup(ifname=ifname)
+        if not idx:
+            msg = f"Interface {ifname} not found"
+            raise WgQuickError(msg)
+        kwargs: dict[str, object] = {"index": idx[0], "state": "up"}
+        if mtu is not None:
+            kwargs["mtu"] = mtu
+        ipr.link("set", **kwargs)
+
+
+def _add_address(
+    ifname: str, address: IPv4Interface | IPv6Interface
+) -> None:
+    with pyroute2.IPRoute() as ipr:
+        idx = ipr.link_lookup(ifname=ifname)
+        if not idx:
+            msg = f"Interface {ifname} not found"
+            raise WgQuickError(msg)
+        ipr.addr(
+            "add",
+            index=idx[0],
+            address=str(address.ip),
+            prefixlen=address.network.prefixlen,
+        )
+
+
+def _add_route(
+    ifname: str,
+    dest: IPv4Network | IPv6Network,
+    *,
+    table: int | None = None,
+) -> None:
+    with pyroute2.IPRoute() as ipr:
+        idx = ipr.link_lookup(ifname=ifname)
+        if not idx:
+            msg = f"Interface {ifname} not found"
+            raise WgQuickError(msg)
+        kwargs: dict[str, object] = {
+            "dst": str(dest),
+            "oif": idx[0],
+        }
+        if table is not None:
+            kwargs["table"] = table
+        try:
+            ipr.route("add", **kwargs)
+        except pyroute2.netlink.exceptions.NetlinkError as exc:
+            if exc.code != 17:  # EEXIST
+                raise
+
+
+def _del_route(
+    ifname: str,
+    dest: IPv4Network | IPv6Network,
+    *,
+    table: int | None = None,
+) -> None:
+    with pyroute2.IPRoute() as ipr:
+        idx = ipr.link_lookup(ifname=ifname)
+        if not idx:
+            return
+        kwargs: dict[str, object] = {
+            "dst": str(dest),
+            "oif": idx[0],
+        }
+        if table is not None:
+            kwargs["table"] = table
+        try:
+            ipr.route("del", **kwargs)
+        except pyroute2.netlink.exceptions.NetlinkError:
+            pass
+
+
+def _add_fwmark_rule(fwmark: int, table: int, family: int) -> None:
+    """Add an ip rule for fwmark-based routing (needed for catch-all AllowedIPs)."""
+    with pyroute2.IPRoute() as ipr:
+        try:
+            ipr.rule(
+                "add",
+                family=family,
+                fwmark=fwmark,
+                lookup=table,
+                priority=32764,
+            )
+        except pyroute2.netlink.exceptions.NetlinkError as exc:
+            if exc.code != 17:
+                raise
+
+
+def _del_fwmark_rule(fwmark: int, table: int, family: int) -> None:
+    with pyroute2.IPRoute() as ipr:
+        try:
+            ipr.rule(
+                "del",
+                family=family,
+                fwmark=fwmark,
+                lookup=table,
+                priority=32764,
+            )
+        except pyroute2.netlink.exceptions.NetlinkError:
+            pass
+
+
+def _add_suppress_prefix_rule(table: int, family: int) -> None:
+    """Suppress prefix-length 0 routes for the main table to avoid routing loops."""
+    with pyroute2.IPRoute() as ipr:
+        try:
+            ipr.rule(
+                "add",
+                family=family,
+                lookup=254,  # main table
+                suppress_prefixlength=0,
+                priority=32765,
+            )
+        except pyroute2.netlink.exceptions.NetlinkError as exc:
+            if exc.code != 17:
+                raise
+
+
+def _del_suppress_prefix_rule(family: int) -> None:
+    with pyroute2.IPRoute() as ipr:
+        try:
+            ipr.rule(
+                "del",
+                family=family,
+                lookup=254,
+                suppress_prefixlength=0,
+                priority=32765,
+            )
+        except pyroute2.netlink.exceptions.NetlinkError:
+            pass
+
+
+def _resolve_table(config: WireguardConfig, ifname: str) -> int | None:
+    """Resolve the Table config value to a routing table number.
+
+    - "off": return None (no route management)
+    - "auto" (default): use interface index as table number when catch-all
+      AllowedIPs are present, otherwise use the main table
+    - numeric: return the explicit table number
+    """
+    table_str = config.table or DEFAULT_TABLE
+    if table_str == "off":
+        return None
+    if table_str == "auto":
+        has_catchall = False
+        for peer in config.peers.values():
+            for aip in peer.allowed_ips:
+                if aip.network.prefixlen == 0:
+                    has_catchall = True
+                    break
+        if has_catchall:
+            with pyroute2.IPRoute() as ipr:
+                idx = ipr.link_lookup(ifname=ifname)
+                return idx[0] if idx else None
+        return None  # use main table (no explicit table arg)
+    return int(table_str)
+
+
+def _collect_allowed_networks(
+    config: WireguardConfig,
+) -> list[IPv4Network | IPv6Network]:
+    """Collect unique AllowedIPs networks across all peers."""
+    seen: set[str] = set()
+    networks: list[IPv4Network | IPv6Network] = []
+    for peer in config.peers.values():
+        for aip in peer.allowed_ips:
+            net = aip.network
+            key = str(net)
+            if key not in seen:
+                seen.add(key)
+                networks.append(net)
+    return networks
+
+
+def _setup_dns(config: WireguardConfig, ifname: str) -> bool:
+    """Set up DNS using resolvconf if available. Returns True if DNS was set."""
+    if not config.dns_servers and not config.search_domains:
+        return False
+    resolvconf = _which("resolvconf")
+    if resolvconf is None:
+        print(
+            "Warning: resolvconf not found, DNS settings will not be applied.",
+            file=sys.stderr,
+        )
+        return False
+    resolvconf_input = config.to_resolvconf()
+    result = subprocess.run(
+        [resolvconf, "-a", f"tun.{ifname}", "-m", "0", "-x"],
+        input=resolvconf_input,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _teardown_dns(ifname: str) -> None:
+    resolvconf = _which("resolvconf")
+    if resolvconf is not None:
+        subprocess.run(
+            [resolvconf, "-d", f"tun.{ifname}"],
+            check=False,
+        )
+
+
+def _which(cmd: str) -> str | None:
+    import shutil
+    return shutil.which(cmd)
+
+
+def up(name_or_path: str) -> None:
+    """Bring up a WireGuard interface (equivalent to ``wg-quick up``)."""
+    ifname, config_path = _find_config(name_or_path)
+
+    if _interface_exists(ifname):
+        msg = f"Interface {ifname} already exists"
+        raise WgQuickError(msg)
+
+    with open(config_path) as f:
+        config = WireguardConfig.from_wgconfig(f)
+
+    # PreUp hooks
+    for cmd in config.preup:
+        _run_hook(cmd, ifname)
+
+    # Create the WireGuard interface
+    _create_interface(ifname)
+
+    try:
+        # Apply WireGuard configuration (keys, peers, etc.)
+        wg_config = WireguardConfig.from_wgconfig(open(config_path))
+        with closing(WireguardDevice.get(ifname)) as device:
+            device.set_config(wg_config)
+
+        # Set addresses
+        for addr in config.addresses:
+            _add_address(ifname, addr)
+
+        # Determine MTU
+        mtu = config.mtu or DEFAULT_MTU_V4
+        _set_link_up(ifname, mtu=mtu)
+
+        # Routing
+        table = _resolve_table(config, ifname)
+        networks = _collect_allowed_networks(config)
+
+        has_catchall_v4 = any(
+            isinstance(n, IPv4Network) and n.prefixlen == 0 for n in networks
+        )
+        has_catchall_v6 = any(
+            isinstance(n, IPv6Network) and n.prefixlen == 0 for n in networks
+        )
+
+        for net in networks:
+            _add_route(ifname, net, table=table)
+
+        # If using fwmark-based routing (auto table with catch-all), set up rules
+        if table is not None and (has_catchall_v4 or has_catchall_v6):
+            fwmark = config.fwmark or 51820
+            if has_catchall_v4:
+                import socket
+                _add_fwmark_rule(fwmark, table, socket.AF_INET)
+                _add_suppress_prefix_rule(table, socket.AF_INET)
+            if has_catchall_v6:
+                import socket
+                _add_fwmark_rule(fwmark, table, socket.AF_INET6)
+                _add_suppress_prefix_rule(table, socket.AF_INET6)
+
+        # DNS
+        _setup_dns(config, ifname)
+
+        # PostUp hooks
+        for cmd in config.postup:
+            _run_hook(cmd, ifname)
+
+    except Exception:
+        # If anything fails after interface creation, clean up
+        _delete_interface(ifname)
+        raise
+
+
+def down(name_or_path: str) -> None:
+    """Bring down a WireGuard interface (equivalent to ``wg-quick down``)."""
+    ifname, config_path = _find_config(name_or_path)
+
+    if not _interface_exists(ifname):
+        msg = f"Interface {ifname} is not currently up"
+        raise WgQuickError(msg)
+
+    with open(config_path) as f:
+        config = WireguardConfig.from_wgconfig(f)
+
+    # PreDown hooks
+    for cmd in config.predown:
+        _run_hook(cmd, ifname)
+
+    # Tear down DNS
+    _teardown_dns(ifname)
+
+    # Remove fwmark rules if they were set
+    table = _resolve_table(config, ifname)
+    networks = _collect_allowed_networks(config)
+    has_catchall_v4 = any(
+        isinstance(n, IPv4Network) and n.prefixlen == 0 for n in networks
+    )
+    has_catchall_v6 = any(
+        isinstance(n, IPv6Network) and n.prefixlen == 0 for n in networks
+    )
+
+    if table is not None and (has_catchall_v4 or has_catchall_v6):
+        fwmark = config.fwmark or 51820
+        import socket
+        if has_catchall_v4:
+            _del_fwmark_rule(fwmark, table, socket.AF_INET)
+            _del_suppress_prefix_rule(socket.AF_INET)
+        if has_catchall_v6:
+            _del_fwmark_rule(fwmark, table, socket.AF_INET6)
+            _del_suppress_prefix_rule(socket.AF_INET6)
+
+    # Remove routes
+    for net in networks:
+        _del_route(ifname, net, table=table)
+
+    # Delete the interface (this also removes addresses)
+    _delete_interface(ifname)
+
+    # PostDown hooks
+    for cmd in config.postdown:
+        _run_hook(cmd, ifname)

--- a/src/wireguard_tools/wg_quick.py
+++ b/src/wireguard_tools/wg_quick.py
@@ -42,8 +42,11 @@ def _find_config(name_or_path: str) -> tuple[str, Path]:
     if p.suffix == ".conf" and p.exists():
         return p.stem, p
     config_path = WG_CONFIG_DIR / f"{name_or_path}.conf"
-    if config_path.exists():
-        return name_or_path, config_path
+    try:
+        if config_path.exists():
+            return name_or_path, config_path
+    except PermissionError:
+        pass
     msg = f"Configuration file not found for '{name_or_path}'"
     raise WgQuickError(msg)
 

--- a/src/wireguard_tools/wg_quick.py
+++ b/src/wireguard_tools/wg_quick.py
@@ -8,6 +8,27 @@
 # for netlink-based interface, address, and route management.
 #
 
+"""Pure-Python reimplementation of ``wg-quick(8)`` interface lifecycle management.
+
+This module provides :func:`up` and :func:`down` entry points that mirror the
+behaviour of the ``wg-quick`` shell script shipped with the upstream
+WireGuard tools.  Network configuration (link creation, address assignment,
+routing, policy rules) is performed via Netlink using :mod:`pyroute2` rather
+than shelling out to ``ip(8)``.
+
+DNS is optionally managed through ``resolvconf(8)`` when available.  Lifecycle
+hook commands (``PreUp``, ``PostUp``, ``PreDown``, ``PostDown``) are executed
+via the system shell with the ``WIREGUARD_INTERFACE`` environment variable set
+to the interface name.
+
+Typical usage from the CLI layer::
+
+    from wireguard_tools.wg_quick import up, down
+
+    up("wg0")   # or up("/etc/wireguard/wg0.conf")
+    down("wg0")
+"""
+
 from __future__ import annotations
 
 import os
@@ -33,11 +54,32 @@ DEFAULT_MTU_V6 = 1420
 
 
 class WgQuickError(RuntimeError):
-    """Raised when a wg-quick operation fails."""
+    """Fatal error during a ``wg-quick`` lifecycle operation.
+
+    Raised by :func:`up`, :func:`down`, and their helpers whenever an
+    operation cannot be completed — for example, a missing configuration file,
+    a failed hook command, or a missing network interface.  The exception
+    message is intended to be displayed directly to the end-user.
+    """
 
 
 def _find_config(name_or_path: str) -> tuple[str, Path]:
-    """Resolve an interface name or config path to (ifname, config_path)."""
+    """Resolve an interface name or configuration file path.
+
+    Resolution rules:
+
+    1. If *name_or_path* has a ``.conf`` suffix **and** the file exists, it is
+       treated as a direct path — the interface name is derived from the stem.
+    2. Otherwise, look for ``/etc/wireguard/<name_or_path>.conf``.
+    3. A :exc:`PermissionError` while checking the ``/etc/wireguard`` path is
+       silently ignored (the caller will receive the "not found" error instead).
+
+    :param name_or_path: Either a bare interface name (e.g. ``"wg0"``) or an
+        absolute/relative path ending in ``.conf``.
+    :returns: A ``(ifname, config_path)`` tuple.
+    :rtype: tuple[str, Path]
+    :raises WgQuickError: If no configuration file can be located.
+    """
     p = Path(name_or_path)
     if p.suffix == ".conf" and p.exists():
         return p.stem, p
@@ -52,7 +94,17 @@ def _find_config(name_or_path: str) -> tuple[str, Path]:
 
 
 def _run_hook(cmd: str, ifname: str) -> None:
-    """Run a PreUp/PostUp/PreDown/PostDown hook command."""
+    """Execute a lifecycle hook command via the system shell.
+
+    The command is run with ``shell=True``.  The process inherits the
+    current environment augmented with ``WIREGUARD_INTERFACE`` set to
+    *ifname*, matching the contract of the upstream ``wg-quick`` script.
+
+    :param cmd: Shell command string (e.g. ``"iptables -A FORWARD ..."``).
+    :param ifname: WireGuard interface name injected into the environment.
+    :rtype: None
+    :raises WgQuickError: If the subprocess exits with a non-zero return code.
+    """
     env = os.environ.copy()
     env["WIREGUARD_INTERFACE"] = ifname
     result = subprocess.run(
@@ -67,17 +119,42 @@ def _run_hook(cmd: str, ifname: str) -> None:
 
 
 def _interface_exists(ifname: str) -> bool:
+    """Check whether a network interface with the given name exists.
+
+    :param ifname: Name of the network interface to look up.
+    :returns: ``True`` if the interface is present, ``False`` otherwise.
+    :rtype: bool
+    """
     with pyroute2.IPRoute() as ipr:
         links = ipr.link_lookup(ifname=ifname)
         return len(links) > 0
 
 
 def _create_interface(ifname: str) -> None:
+    """Create a new WireGuard network interface via Netlink.
+
+    The interface is created with ``kind="wireguard"`` and starts in the
+    *down* state.  Callers are responsible for applying configuration and
+    bringing the link up afterward.
+
+    :param ifname: Desired interface name (e.g. ``"wg0"``).
+    :rtype: None
+    :raises pyroute2.netlink.exceptions.NetlinkError: If the interface
+        already exists or the kernel module is unavailable.
+    """
     with pyroute2.IPRoute() as ipr:
         ipr.link("add", ifname=ifname, kind="wireguard")
 
 
 def _delete_interface(ifname: str) -> None:
+    """Delete a network interface by name.
+
+    If the interface does not exist the call is a silent no-op, making it safe
+    to use in cleanup/rollback paths.
+
+    :param ifname: Interface name to delete.
+    :rtype: None
+    """
     with pyroute2.IPRoute() as ipr:
         idx = ipr.link_lookup(ifname=ifname)
         if idx:
@@ -85,6 +162,14 @@ def _delete_interface(ifname: str) -> None:
 
 
 def _set_link_up(ifname: str, mtu: int | None = None) -> None:
+    """Bring a network interface up, optionally setting its MTU.
+
+    :param ifname: Interface name to bring up.
+    :param mtu: If not ``None``, the MTU is set atomically with the state
+        change.
+    :rtype: None
+    :raises WgQuickError: If the interface cannot be found.
+    """
     with pyroute2.IPRoute() as ipr:
         idx = ipr.link_lookup(ifname=ifname)
         if not idx:
@@ -99,6 +184,14 @@ def _set_link_up(ifname: str, mtu: int | None = None) -> None:
 def _add_address(
     ifname: str, address: IPv4Interface | IPv6Interface
 ) -> None:
+    """Assign an IP address to a network interface.
+
+    :param ifname: Interface name to configure.
+    :param address: IPv4 or IPv6 interface address including prefix length
+        (e.g. ``IPv4Interface("10.0.0.1/24")``).
+    :rtype: None
+    :raises WgQuickError: If the interface cannot be found.
+    """
     with pyroute2.IPRoute() as ipr:
         idx = ipr.link_lookup(ifname=ifname)
         if not idx:
@@ -118,6 +211,19 @@ def _add_route(
     *,
     table: int | None = None,
 ) -> None:
+    """Add a route for *dest* via the named interface.
+
+    If the route already exists (``EEXIST`` / errno 17) the error is silently
+    ignored, making this call idempotent.
+
+    :param ifname: Outgoing interface name.
+    :param dest: Destination network (e.g. ``IPv4Network("10.0.0.0/24")``).
+    :param table: Routing table number.  ``None`` means the main table.
+    :rtype: None
+    :raises WgQuickError: If the interface cannot be found.
+    :raises pyroute2.netlink.exceptions.NetlinkError: For Netlink errors other
+        than ``EEXIST``.
+    """
     with pyroute2.IPRoute() as ipr:
         idx = ipr.link_lookup(ifname=ifname)
         if not idx:
@@ -142,6 +248,17 @@ def _del_route(
     *,
     table: int | None = None,
 ) -> None:
+    """Remove a route for *dest* via the named interface.
+
+    All Netlink errors are silently suppressed so this function is safe to call
+    during teardown even when the route has already been removed.  If the
+    interface no longer exists the call is a no-op.
+
+    :param ifname: Outgoing interface name.
+    :param dest: Destination network to remove.
+    :param table: Routing table number.  ``None`` means the main table.
+    :rtype: None
+    """
     with pyroute2.IPRoute() as ipr:
         idx = ipr.link_lookup(ifname=ifname)
         if not idx:
@@ -159,7 +276,22 @@ def _del_route(
 
 
 def _add_fwmark_rule(fwmark: int, table: int, family: int) -> None:
-    """Add an ip rule for fwmark-based routing (needed for catch-all AllowedIPs)."""
+    """Add an ``ip rule`` for fwmark-based routing.
+
+    Required when catch-all (``0.0.0.0/0`` or ``::/0``) AllowedIPs are
+    present so that traffic *from* the WireGuard tunnel itself (already
+    marked with *fwmark*) is directed to the correct routing table and does
+    not loop back into the tunnel.  The rule is installed at priority 32764.
+
+    If the rule already exists (``EEXIST``) the error is silently ignored.
+
+    :param fwmark: Firewall mark value to match.
+    :param table: Routing table to direct matching packets to.
+    :param family: Address family (``socket.AF_INET`` or ``socket.AF_INET6``).
+    :rtype: None
+    :raises pyroute2.netlink.exceptions.NetlinkError: For Netlink errors other
+        than ``EEXIST``.
+    """
     with pyroute2.IPRoute() as ipr:
         try:
             ipr.rule(
@@ -175,6 +307,16 @@ def _add_fwmark_rule(fwmark: int, table: int, family: int) -> None:
 
 
 def _del_fwmark_rule(fwmark: int, table: int, family: int) -> None:
+    """Remove the fwmark-based routing rule created by :func:`_add_fwmark_rule`.
+
+    All Netlink errors are silently suppressed so this is safe to call during
+    teardown even when the rule has already been removed.
+
+    :param fwmark: Firewall mark value to match.
+    :param table: Routing table that was used when the rule was created.
+    :param family: Address family (``socket.AF_INET`` or ``socket.AF_INET6``).
+    :rtype: None
+    """
     with pyroute2.IPRoute() as ipr:
         try:
             ipr.rule(
@@ -189,7 +331,23 @@ def _del_fwmark_rule(fwmark: int, table: int, family: int) -> None:
 
 
 def _add_suppress_prefix_rule(table: int, family: int) -> None:
-    """Suppress prefix-length 0 routes for the main table to avoid routing loops."""
+    """Add a suppress-prefixlength rule to prevent routing loops.
+
+    When a catch-all (``0.0.0.0/0`` or ``::/0``) route is installed in a
+    non-main routing table, the main table's default route would normally
+    still match.  This rule (priority 32765) tells the kernel to *skip* the
+    main table lookup when the matching route has a prefix length of 0,
+    ensuring that only more-specific routes from the main table are used.
+
+    If the rule already exists (``EEXIST``) the error is silently ignored.
+
+    :param table: Routing table number (unused directly — the rule always
+        targets table 254 / main).
+    :param family: Address family (``socket.AF_INET`` or ``socket.AF_INET6``).
+    :rtype: None
+    :raises pyroute2.netlink.exceptions.NetlinkError: For Netlink errors other
+        than ``EEXIST``.
+    """
     with pyroute2.IPRoute() as ipr:
         try:
             ipr.rule(
@@ -205,6 +363,14 @@ def _add_suppress_prefix_rule(table: int, family: int) -> None:
 
 
 def _del_suppress_prefix_rule(family: int) -> None:
+    """Remove the suppress-prefixlength rule created by :func:`_add_suppress_prefix_rule`.
+
+    All Netlink errors are silently suppressed so this is safe to call during
+    teardown even when the rule has already been removed.
+
+    :param family: Address family (``socket.AF_INET`` or ``socket.AF_INET6``).
+    :rtype: None
+    """
     with pyroute2.IPRoute() as ipr:
         try:
             ipr.rule(
@@ -219,12 +385,25 @@ def _del_suppress_prefix_rule(family: int) -> None:
 
 
 def _resolve_table(config: WireguardConfig, ifname: str) -> int | None:
-    """Resolve the Table config value to a routing table number.
+    """Resolve the ``Table`` configuration directive to a routing table number.
 
-    - "off": return None (no route management)
-    - "auto" (default): use interface index as table number when catch-all
-      AllowedIPs are present, otherwise use the main table
-    - numeric: return the explicit table number
+    Behaviour:
+
+    * ``"off"`` — return ``None``.  No route management is performed and all
+      routes must be managed externally.
+    * ``"auto"`` (the default when ``Table`` is absent) — if *any* peer has a
+      catch-all AllowedIP (``0.0.0.0/0`` or ``::/0``), the interface's own
+      kernel index is used as the routing table number (enabling policy-based
+      routing with fwmark rules).  When there is no catch-all, ``None`` is
+      returned and routes are added to the main table.
+    * An explicit numeric string — parsed and returned as an ``int``.
+
+    :param config: The parsed WireGuard configuration.
+    :param ifname: The interface name (used to look up the kernel interface
+        index in the ``"auto"`` case).
+    :returns: A routing table number, or ``None`` when routes should go into
+        the main table or route management is disabled.
+    :rtype: int | None
     """
     table_str = config.table or DEFAULT_TABLE
     if table_str == "off":
@@ -247,7 +426,17 @@ def _resolve_table(config: WireguardConfig, ifname: str) -> int | None:
 def _collect_allowed_networks(
     config: WireguardConfig,
 ) -> list[IPv4Network | IPv6Network]:
-    """Collect unique AllowedIPs networks across all peers."""
+    """Collect deduplicated AllowedIPs networks across all peers.
+
+    Iterates every peer's ``allowed_ips`` and returns the distinct *network*
+    portion of each entry in first-seen order.  Deduplication is based on the
+    string representation of the network, so ``10.0.0.0/24`` appearing in two
+    peers is returned only once.
+
+    :param config: The parsed WireGuard configuration.
+    :returns: An ordered list of unique networks.
+    :rtype: list[IPv4Network | IPv6Network]
+    """
     seen: set[str] = set()
     networks: list[IPv4Network | IPv6Network] = []
     for peer in config.peers.values():
@@ -261,7 +450,23 @@ def _collect_allowed_networks(
 
 
 def _setup_dns(config: WireguardConfig, ifname: str) -> bool:
-    """Set up DNS using resolvconf if available. Returns True if DNS was set."""
+    """Configure DNS servers and search domains via ``resolvconf(8)``.
+
+    If the configuration contains ``DNS`` or ``SearchDomain`` entries and
+    ``resolvconf`` is found on ``$PATH``, its ``-a`` subcommand is invoked
+    with metric ``0`` and exclusive mode (``-x``) to register name-servers
+    under the ``tun.<ifname>`` scope.
+
+    When ``resolvconf`` is not installed a warning is printed to stderr and
+    no DNS changes are made.
+
+    :param config: The parsed WireGuard configuration (supplies
+        :attr:`dns_servers` and :attr:`search_domains`).
+    :param ifname: Interface name used as the ``resolvconf`` scope identifier.
+    :returns: ``True`` if DNS was successfully configured, ``False`` otherwise
+        (including when no DNS settings are present).
+    :rtype: bool
+    """
     if not config.dns_servers and not config.search_domains:
         return False
     resolvconf = _which("resolvconf")
@@ -282,6 +487,14 @@ def _setup_dns(config: WireguardConfig, ifname: str) -> bool:
 
 
 def _teardown_dns(ifname: str) -> None:
+    """Remove DNS configuration previously registered by :func:`_setup_dns`.
+
+    Calls ``resolvconf -d tun.<ifname>`` to unregister the scope.  If
+    ``resolvconf`` is not installed the call is a silent no-op.
+
+    :param ifname: Interface name whose DNS scope should be removed.
+    :rtype: None
+    """
     resolvconf = _which("resolvconf")
     if resolvconf is not None:
         subprocess.run(
@@ -291,12 +504,48 @@ def _teardown_dns(ifname: str) -> None:
 
 
 def _which(cmd: str) -> str | None:
+    """Locate an executable on ``$PATH``.
+
+    Thin wrapper around :func:`shutil.which` extracted for test-time
+    monkey-patching.
+
+    :param cmd: Executable name to search for.
+    :returns: Absolute path to the executable, or ``None`` if not found.
+    :rtype: str | None
+    """
     import shutil
     return shutil.which(cmd)
 
 
 def up(name_or_path: str) -> None:
-    """Bring up a WireGuard interface (equivalent to ``wg-quick up``)."""
+    """Bring up a WireGuard interface (equivalent to ``wg-quick up``).
+
+    Full lifecycle:
+
+    1. Resolve the configuration file via :func:`_find_config`.
+    2. Verify the interface does not already exist.
+    3. Execute ``PreUp`` hook commands.
+    4. Create the WireGuard network interface.
+    5. Apply cryptographic and peer configuration via
+       :meth:`~wireguard_tools.wireguard_device.WireguardDevice.set_config`.
+    6. Assign ``Address`` entries to the interface.
+    7. Set MTU (from config or :data:`DEFAULT_MTU_V4`) and bring the link up.
+    8. Resolve routing table (see :func:`_resolve_table`), install routes for
+       every unique AllowedIP network, and — when catch-all routes are present
+       — add fwmark and suppress-prefixlength policy rules.
+    9. Configure DNS via :func:`_setup_dns`.
+    10. Execute ``PostUp`` hook commands.
+
+    **Rollback on failure:** if any step after interface creation raises an
+    exception, the interface is deleted before the exception propagates,
+    preventing a half-configured interface from lingering.
+
+    :param name_or_path: Interface name (e.g. ``"wg0"``) or path to a
+        ``.conf`` file.
+    :rtype: None
+    :raises WgQuickError: If the interface already exists, the configuration
+        file is missing, or any sub-step fails.
+    """
     ifname, config_path = _find_config(name_or_path)
 
     if _interface_exists(ifname):
@@ -368,7 +617,31 @@ def up(name_or_path: str) -> None:
 
 
 def down(name_or_path: str) -> None:
-    """Bring down a WireGuard interface (equivalent to ``wg-quick down``)."""
+    """Tear down a WireGuard interface (equivalent to ``wg-quick down``).
+
+    Full lifecycle:
+
+    1. Resolve the configuration file via :func:`_find_config`.
+    2. Verify the interface currently exists.
+    3. Execute ``PreDown`` hook commands.
+    4. Remove DNS configuration via :func:`_teardown_dns`.
+    5. If catch-all AllowedIPs are present, remove the fwmark and
+       suppress-prefixlength policy rules.
+    6. Remove all routes that were installed for AllowedIP networks.
+    7. Delete the WireGuard network interface (which also implicitly removes
+       associated addresses).
+    8. Execute ``PostDown`` hook commands.
+
+    Unlike :func:`up`, there is no rollback — each teardown step is
+    best-effort and proceeds to the next even if an individual step fails
+    (e.g. a route was already removed externally).
+
+    :param name_or_path: Interface name (e.g. ``"wg0"``) or path to a
+        ``.conf`` file.
+    :rtype: None
+    :raises WgQuickError: If the interface is not currently up or the
+        configuration file is missing.
+    """
     ifname, config_path = _find_config(name_or_path)
 
     if not _interface_exists(ifname):

--- a/src/wireguard_tools/wg_quick.py
+++ b/src/wireguard_tools/wg_quick.py
@@ -315,7 +315,8 @@ def up(name_or_path: str) -> None:
 
     try:
         # Apply WireGuard configuration (keys, peers, etc.)
-        wg_config = WireguardConfig.from_wgconfig(open(config_path))
+        with open(config_path) as f:
+            wg_config = WireguardConfig.from_wgconfig(f)
         with closing(WireguardDevice.get(ifname)) as device:
             device.set_config(wg_config)
 

--- a/src/wireguard_tools/wireguard_config.py
+++ b/src/wireguard_tools/wireguard_config.py
@@ -30,6 +30,23 @@ SimpleJsonTypes = Union[str, int, float, bool, None]
 T = TypeVar("T")
 
 
+def _parse_endpoint(value: str) -> tuple[str, int]:
+    """Parse an endpoint string into (host, port), handling IPv6 bracket notation."""
+    if value.startswith("["):
+        bracket_end = value.index("]")
+        host = value[1:bracket_end]
+        port = int(value[bracket_end + 2 :])
+    else:
+        host, port_str = value.rsplit(":", 1)
+        port = int(port_str)
+    return host, port
+
+
+def _split_comma_list(value: str) -> list[str]:
+    """Split a comma-separated value list, tolerating whitespace and empty entries."""
+    return [item for item in (s.strip() for s in value.split(",")) if item]
+
+
 def _ipaddress_or_host(
     host: IPv4Address | IPv6Address | str,
 ) -> IPv4Address | IPv6Address | str:
@@ -87,9 +104,9 @@ class WireguardPeer:
     def from_dict(cls, config_dict: dict[str, Any]) -> WireguardPeer:
         endpoint = config_dict.pop("endpoint", None)
         if endpoint is not None:
-            host, port = endpoint.rsplit(":", 1)
+            host, port = _parse_endpoint(endpoint)
             config_dict["endpoint_host"] = host
-            config_dict["endpoint_port"] = int(port)
+            config_dict["endpoint_port"] = port
         return cls(**config_dict)
 
     def asdict(self) -> dict[str, Any]:
@@ -116,14 +133,14 @@ class WireguardPeer:
             elif key == "presharedkey":
                 conf["preshared_key"] = WireguardKey(value)
             elif key == "endpoint":
-                host, port = value.rsplit(":", 1)
+                host, port = _parse_endpoint(value)
                 conf["endpoint_host"] = host
-                conf["endpoint_port"] = int(port)
+                conf["endpoint_port"] = port
             elif key == "persistentkeepalive":
                 conf["persistent_keepalive"] = int(value)
             elif key == "allowedips":
                 conf.setdefault("allowed_ips", []).extend(
-                    ip_interface(addr.strip()) for addr in value.split(",")
+                    ip_interface(addr) for addr in _split_comma_list(value)
                 )
             elif key == "# friendly_name":
                 conf["friendly_name"] = value
@@ -142,7 +159,11 @@ class WireguardPeer:
         if self.preshared_key:
             conf.append(f"PresharedKey = {self.preshared_key}")
         if self.endpoint_host:
-            conf.append(f"Endpoint = {self.endpoint_host}:{self.endpoint_port}")
+            host = self.endpoint_host
+            if isinstance(host, IPv6Address):
+                conf.append(f"Endpoint = [{host}]:{self.endpoint_port}")
+            else:
+                conf.append(f"Endpoint = {host}:{self.endpoint_port}")
         if self.persistent_keepalive:
             conf.append(f"PersistentKeepalive = {self.persistent_keepalive}")
         conf.extend([f"AllowedIPs = {addr}" for addr in self.allowed_ips])
@@ -276,17 +297,17 @@ class WireguardConfig:
             if key == "privatekey":
                 self.private_key = WireguardKey(value)
             elif key == "fwmark":
-                self.fwmark = int(value)
+                self.fwmark = int(value, 0)
             elif key == "listenport":
                 self.listen_port = int(value)
             # wg-quick specific extensions
             elif key == "address":
                 self.addresses.extend(
-                    ip_interface(addr.strip()) for addr in value.split(",")
+                    ip_interface(addr) for addr in _split_comma_list(value)
                 )
             elif key == "dns":
-                for item in value.split(","):
-                    self._add_dns_entry(item.strip())
+                for item in _split_comma_list(value):
+                    self._add_dns_entry(item)
             elif key == "mtu":
                 self.mtu = int(value)
             elif key == "table":
@@ -300,16 +321,12 @@ class WireguardConfig:
             elif key == "postdown":
                 self.postdown.append(value)
             elif key == "saveconfig":
-                self.saveconfig = value == "true"
+                self.saveconfig = value.lower() == "true"
             # wireguard-android specific extensions
             elif key == "includedapplications":
-                self.included_applications.extend(
-                    item.strip() for item in value.split(",")
-                )
+                self.included_applications.extend(_split_comma_list(value))
             elif key == "excludedapplications":
-                self.excluded_applications.extend(
-                    item.strip() for item in value.split(",")
-                )
+                self.excluded_applications.extend(_split_comma_list(value))
 
     def _add_dns_entry(self, item: str) -> None:
         try:

--- a/src/wireguard_tools/wireguard_config.py
+++ b/src/wireguard_tools/wireguard_config.py
@@ -5,6 +5,19 @@
 # SPDX-License-Identifier: MIT
 #
 
+"""Data-model classes for WireGuard interface and peer configuration.
+
+This module provides :class:`WireguardConfig` and :class:`WireguardPeer`,
+attrs-based data classes that represent a complete WireGuard interface
+configuration.  Configurations can be round-tripped through the INI-style
+``wg(8)``/``wg-quick(8)`` config format, plain dictionaries (suitable for
+JSON serialisation), and QR codes consumed by mobile clients.
+
+The module also supports wg-quick extensions (addresses, DNS, routing table,
+pre/post hooks) and wireguard-android extensions (included/excluded
+applications).
+"""
+
 from __future__ import annotations
 
 import json
@@ -31,7 +44,19 @@ T = TypeVar("T")
 
 
 def _parse_endpoint(value: str) -> tuple[str, int]:
-    """Parse an endpoint string into (host, port), handling IPv6 bracket notation."""
+    """Parse an endpoint address string into a host/port pair.
+
+    Handles both plain ``host:port`` notation and IPv6 bracket notation
+    ``[host]:port``.
+
+    :param value: Endpoint string, e.g. ``"203.0.113.1:51820"`` or
+        ``"[2001:db8::1]:51820"``.
+    :returns: A ``(host, port)`` tuple where *host* is the bare address
+        string (brackets stripped) and *port* is the numeric port.
+    :rtype: tuple[str, int]
+    :raises ValueError: If the port component is not a valid integer.
+    :raises ValueError: If bracket notation is malformed (missing ``]``).
+    """
     if value.startswith("["):
         bracket_end = value.index("]")
         host = value[1:bracket_end]
@@ -43,13 +68,35 @@ def _parse_endpoint(value: str) -> tuple[str, int]:
 
 
 def _split_comma_list(value: str) -> list[str]:
-    """Split a comma-separated value list, tolerating whitespace and empty entries."""
+    """Split a comma-separated string into a list of stripped, non-empty items.
+
+    Leading/trailing whitespace around each item is stripped and empty
+    entries (e.g. from trailing commas) are silently discarded.
+
+    :param value: Comma-separated string, e.g. ``"10.0.0.1, 10.0.0.2,"``.
+    :returns: List of non-empty stripped strings.
+    :rtype: list[str]
+    """
     return [item for item in (s.strip() for s in value.split(",")) if item]
 
 
 def _ipaddress_or_host(
     host: IPv4Address | IPv6Address | str,
 ) -> IPv4Address | IPv6Address | str:
+    """Coerce a value to an IP address, falling back to a plain hostname string.
+
+    If *host* is already an :class:`~ipaddress.IPv4Address` or
+    :class:`~ipaddress.IPv6Address` it is returned as-is.  String values are
+    first stripped of surrounding brackets (to handle ``[IPv6]`` notation)
+    and then parsed; if parsing fails the original string is returned
+    unchanged, allowing DNS hostnames to pass through.
+
+    :param host: IP address object or string representation of an address
+        or hostname.
+    :returns: Parsed IP address, or the original string if it cannot be
+        parsed as an address.
+    :rtype: IPv4Address | IPv6Address | str
+    """
     if isinstance(host, (IPv4Address, IPv6Address)):
         return host
     try:
@@ -61,17 +108,53 @@ def _ipaddress_or_host(
 def _list_of_ipaddress(
     hosts: Sequence[IPv4Address | IPv6Address | str],
 ) -> Sequence[IPv4Address | IPv6Address]:
+    """Convert a sequence of address-like values to a list of IP address objects.
+
+    :param hosts: Sequence of :class:`~ipaddress.IPv4Address`,
+        :class:`~ipaddress.IPv6Address`, or string representations.
+    :returns: List of parsed IP address objects.
+    :rtype: Sequence[IPv4Address | IPv6Address]
+    :raises ValueError: If any element cannot be parsed as an IP address.
+    """
     return [ip_address(host) for host in hosts]
 
 
 def _list_of_ipinterface(
     hosts: Sequence[IPv4Interface | IPv6Interface | str],
 ) -> Sequence[IPv4Interface | IPv6Interface]:
+    """Convert a sequence of interface-like values to a list of IP interface objects.
+
+    :param hosts: Sequence of :class:`~ipaddress.IPv4Interface`,
+        :class:`~ipaddress.IPv6Interface`, or string representations
+        (e.g. ``"10.0.0.1/24"``).
+    :returns: List of parsed IP interface objects.
+    :rtype: Sequence[IPv4Interface | IPv6Interface]
+    :raises ValueError: If any element cannot be parsed as an IP interface.
+    """
     return [ip_interface(host) for host in hosts]
 
 
 @define(on_setattr=setters_convert)
 class WireguardPeer:
+    """A single WireGuard peer entry.
+
+    Each peer is identified by its :attr:`public_key` and optionally carries
+    an :attr:`endpoint_host`/:attr:`endpoint_port` pair, a
+    :attr:`preshared_key`, a :attr:`persistent_keepalive` interval, and a
+    list of :attr:`allowed_ips` (CIDR networks routed through this peer).
+
+    The :attr:`friendly_name` and :attr:`friendly_json` fields store
+    comment-based metadata compatible with
+    `prometheus-wireguard-exporter
+    <https://github.com/MindFlavor/prometheus_wireguard_exporter>`_,
+    which embeds them as ``# friendly_name`` / ``# friendly_json`` comment
+    lines in the config file.
+
+    Runtime statistics (:attr:`last_handshake`, :attr:`rx_bytes`,
+    :attr:`tx_bytes`) are populated when a peer is read from a live device
+    and are excluded from equality comparisons.
+    """
+
     public_key: WireguardKey = field(converter=WireguardKey)
     preshared_key: WireguardKey | None = field(
         converter=optional(WireguardKey),
@@ -102,6 +185,19 @@ class WireguardPeer:
 
     @classmethod
     def from_dict(cls, config_dict: dict[str, Any]) -> WireguardPeer:
+        """Construct a :class:`WireguardPeer` from a plain dictionary.
+
+        If the dictionary contains an ``"endpoint"`` key (e.g.
+        ``"203.0.113.1:51820"``), it is parsed and split into
+        ``endpoint_host`` / ``endpoint_port`` before construction.
+
+        :param config_dict: Dictionary of peer attributes.  Keys should match
+            constructor parameter names, except ``endpoint`` which is
+            automatically split.  **Modified in place** (the ``endpoint`` key
+            is popped).
+        :returns: New peer instance.
+        :rtype: WireguardPeer
+        """
         endpoint = config_dict.pop("endpoint", None)
         if endpoint is not None:
             host, port = _parse_endpoint(endpoint)
@@ -110,6 +206,16 @@ class WireguardPeer:
         return cls(**config_dict)
 
     def asdict(self) -> dict[str, Any]:
+        """Serialise this peer to a plain dictionary.
+
+        ``None`` values are omitted, and IP address / key objects are
+        converted to their string representations so the result is directly
+        JSON-serialisable.
+
+        :returns: Dictionary of non-``None`` peer attributes.
+        :rtype: dict[str, Any]
+        """
+
         def _filter(_attr: Any, value: Any) -> bool:
             return value is not None
 
@@ -125,6 +231,23 @@ class WireguardPeer:
 
     @classmethod
     def from_wgconfig(cls, config: Sequence[tuple[str, str]]) -> WireguardPeer:
+        """Construct a :class:`WireguardPeer` from parsed config key-value pairs.
+
+        Accepts the sequence of ``(key, value)`` string tuples extracted from
+        a ``[Peer]`` section of a ``wg(8)`` configuration file.  Keys are
+        matched case-insensitively.  ``AllowedIPs`` entries are accumulated
+        across multiple lines.
+
+        Comment-based tags ``# friendly_name`` and ``# friendly_json`` are
+        recognised for prometheus-wireguard-exporter compatibility.
+
+        :param config: Ordered sequence of ``(key, value)`` pairs from the
+            config section.
+        :returns: New peer instance.
+        :rtype: WireguardPeer
+        :raises KeyError: If a required key (e.g. ``PublicKey``) is missing
+            from *config*.
+        """
         conf: dict[str, Any] = {}
         for key_, value in config:
             key = key_.lower()
@@ -149,6 +272,15 @@ class WireguardPeer:
         return cls(**conf)
 
     def as_wgconfig_snippet(self) -> list[str]:
+        """Render this peer as lines for a ``wg(8)`` configuration file.
+
+        The returned list starts with a blank line and the ``[Peer]`` section
+        header, followed by all configured fields.  IPv6 endpoint addresses
+        are wrapped in brackets.
+
+        :returns: List of configuration file lines (without trailing newlines).
+        :rtype: list[str]
+        """
         conf = ["\n[Peer]"]
         if self.friendly_name:
             conf.append(f"# friendly_name = {self.friendly_name}")
@@ -170,6 +302,12 @@ class WireguardPeer:
         return conf
 
     def __str__(self) -> str:
+        """Return a human-readable summary of the peer, similar to ``wg show`` output.
+
+        :returns: Multi-line string describing the peer's key, endpoint,
+            keepalive, allowed IPs, handshake time, and transfer statistics.
+        :rtype: str
+        """
         desc = [f"peer: {self.public_key}"]
         if self.preshared_key:
             desc.append(f"  preshared key: {self.preshared_key}")
@@ -193,6 +331,24 @@ class WireguardPeer:
 
 @define(on_setattr=setters_convert)
 class WireguardConfig:
+    """Complete configuration for a WireGuard interface.
+
+    Holds the interface-level settings (:attr:`private_key`,
+    :attr:`listen_port`, :attr:`fwmark`) and a mapping of :attr:`peers`
+    keyed by their :class:`~wireguard_tools.wireguard_key.WireguardKey`.
+
+    In addition to the core WireGuard settings, this class models
+    **wg-quick extensions** (:attr:`addresses`, :attr:`dns_servers`,
+    :attr:`search_domains`, :attr:`mtu`, :attr:`table`,
+    :attr:`preup`/:attr:`postup`/:attr:`predown`/:attr:`postdown` hooks,
+    :attr:`saveconfig`) and **wireguard-android extensions**
+    (:attr:`included_applications`, :attr:`excluded_applications`).
+
+    Instances can be created from dictionaries (:meth:`from_dict`),
+    ``wg(8)``-style config files (:meth:`from_wgconfig`), and serialised
+    back via :meth:`to_wgconfig`, :meth:`asdict`, or :meth:`to_qrcode`.
+    """
+
     private_key: WireguardKey | None = field(
         converter=optional(WireguardKey),
         default=None,
@@ -226,6 +382,18 @@ class WireguardConfig:
 
     @classmethod
     def from_dict(cls, config_dict: dict[str, Any]) -> WireguardConfig:
+        """Construct a :class:`WireguardConfig` from a plain dictionary.
+
+        The ``"dns"`` key, if present, is split into :attr:`dns_servers` and
+        :attr:`search_domains` via :meth:`_add_dns_entry`.  The ``"peers"``
+        list is converted to :class:`WireguardPeer` instances.  All other
+        keys are forwarded to the constructor.
+
+        :param config_dict: Dictionary of interface attributes.  **Not
+            modified** (a shallow copy is made).
+        :returns: New config instance.
+        :rtype: WireguardConfig
+        """
         config_dict = config_dict.copy()
 
         dns = config_dict.pop("dns", [])
@@ -242,6 +410,16 @@ class WireguardConfig:
         return config
 
     def asdict(self) -> dict[str, Any]:
+        """Serialise this configuration to a plain dictionary.
+
+        ``None`` values are omitted.  The :attr:`peers` mapping is converted
+        to a list of peer dictionaries.  IP address and key objects are
+        stringified so the result is directly JSON-serialisable.
+
+        :returns: Dictionary of non-``None`` interface and peer attributes.
+        :rtype: dict[str, Any]
+        """
+
         def _filter(_attr: Any, value: Any) -> bool:
             return value is not None
 
@@ -263,6 +441,19 @@ class WireguardConfig:
 
     @classmethod
     def from_wgconfig(cls, configfile: TextIO) -> WireguardConfig:
+        """Parse a ``wg(8)``/``wg-quick(8)`` configuration file.
+
+        The file is split on ``[Interface]`` and ``[Peer]`` section headers.
+        Exactly one ``[Interface]`` section is expected; multiple ``[Peer]``
+        sections are supported.
+
+        :param configfile: Readable text stream positioned at the start of a
+            WireGuard configuration file.
+        :returns: New config instance.
+        :rtype: WireguardConfig
+        :raises ValueError: If the file contains more than one
+            ``[Interface]`` section.
+        """
         text = configfile.read()
         _pre, *parts = re.split(
             r"^\[(Interface|Peer)\]$",
@@ -292,6 +483,16 @@ class WireguardConfig:
         return config
 
     def _update_from_conf(self, key_value: Sequence[tuple[str, str]]) -> None:
+        """Apply parsed key-value pairs from an ``[Interface]`` section.
+
+        Recognised keys are mapped to their corresponding attributes.
+        ``wg-quick`` extensions (``Address``, ``DNS``, ``MTU``, ``Table``,
+        ``PreUp``/``PostUp``/``PreDown``/``PostDown``, ``SaveConfig``) and
+        ``wireguard-android`` extensions (``IncludedApplications``,
+        ``ExcludedApplications``) are processed when present.
+
+        :param key_value: Ordered sequence of ``(key, value)`` string pairs.
+        """
         for key_, value in key_value:
             key = key_.lower()
             if key == "privatekey":
@@ -329,18 +530,51 @@ class WireguardConfig:
                 self.excluded_applications.extend(_split_comma_list(value))
 
     def _add_dns_entry(self, item: str) -> None:
+        """Classify and store a single DNS entry.
+
+        If *item* can be parsed as an IP address it is appended to
+        :attr:`dns_servers`; otherwise it is treated as a search domain and
+        appended to :attr:`search_domains`.
+
+        :param item: IP address string or DNS search domain.
+        """
         try:
             self.dns_servers.append(ip_address(item))
         except ValueError:
             self.search_domains.append(item)
 
     def add_peer(self, peer: WireguardPeer) -> None:
+        """Add or replace a peer in this configuration.
+
+        The peer is stored under its :attr:`~WireguardPeer.public_key`.  If a
+        peer with the same key already exists it is silently replaced.
+
+        :param peer: Peer instance to add.
+        """
         self.peers[peer.public_key] = peer
 
     def del_peer(self, peer_key: WireguardKey) -> None:
+        """Remove a peer by its public key.
+
+        :param peer_key: Public key of the peer to remove.
+        :raises KeyError: If no peer with *peer_key* exists.
+        """
         del self.peers[peer_key]
 
     def to_wgconfig(self, *, wgquick_format: bool = False) -> str:
+        """Render this configuration as a ``wg(8)`` INI-style config string.
+
+        When *wgquick_format* is ``True``, wg-quick and wireguard-android
+        extensions (addresses, DNS, MTU, hooks, included/excluded
+        applications, etc.) are included in the output.  Otherwise only core
+        WireGuard directives are emitted.
+
+        :param wgquick_format: Include wg-quick and Android extensions.
+            Defaults to ``False``.
+        :returns: Complete configuration file content, terminated by a
+            trailing newline.
+        :rtype: str
+        """
         conf = ["[Interface]"]
         if self.private_key is not None:
             conf.append(f"PrivateKey = {self.private_key}")
@@ -376,6 +610,16 @@ class WireguardConfig:
         return "\n".join(conf)
 
     def to_resolvconf(self, opt_ndots: int | None = None) -> str:
+        """Generate a ``resolv.conf(5)``-style string from DNS settings.
+
+        Includes ``nameserver`` lines for each entry in :attr:`dns_servers`,
+        a ``search`` line if :attr:`search_domains` is non-empty, and an
+        optional ``options ndots:N`` directive.
+
+        :param opt_ndots: If not ``None``, an ``ndots`` option is appended.
+        :returns: ``resolv.conf`` content terminated by a trailing newline.
+        :rtype: str
+        """
         conf = [f"nameserver {addr}" for addr in self.dns_servers]
         if self.search_domains:
             search_domains = " ".join(self.search_domains)
@@ -386,10 +630,24 @@ class WireguardConfig:
         return "\n".join(conf)
 
     def to_qrcode(self) -> QRCode:
+        """Encode this configuration as a QR code suitable for mobile clients.
+
+        The full wg-quick format (including extensions) is encoded as a
+        UTF-8 byte-mode QR code using :func:`segno.make_qr`.
+
+        :returns: A :class:`segno.QRCode` object that can be saved or
+            displayed.
+        :rtype: segno.QRCode
+        """
         config = self.to_wgconfig(wgquick_format=True)
         return make_qr(config, mode="byte", encoding="utf-8", eci=True)
 
     def __str__(self) -> str:
+        """Return a human-readable summary, similar to ``wg show`` output.
+
+        :returns: Multi-line string describing the interface and its peers.
+        :rtype: str
+        """
         desc = []
         if self.private_key is not None:
             desc.append(f"  public key: {self.private_key.public_key()}")

--- a/src/wireguard_tools/wireguard_device.py
+++ b/src/wireguard_tools/wireguard_device.py
@@ -26,7 +26,16 @@ class WireguardDevice(ABC):
     def get_config(self) -> WireguardConfig: ...
 
     @abstractmethod
-    def set_config(self, config: WireguardConfig) -> None: ...
+    def set_config(self, config: WireguardConfig) -> None:
+        """Atomically replace the full interface configuration (setconf)."""
+        ...
+
+    def sync_config(self, config: WireguardConfig) -> None:
+        """Diff against running config and apply only changes (syncconf).
+
+        Subclasses may override with an optimized implementation.
+        """
+        self.set_config(config)
 
     @classmethod
     def get(cls, ifname: str) -> WireguardDevice:

--- a/src/wireguard_tools/wireguard_device.py
+++ b/src/wireguard_tools/wireguard_device.py
@@ -5,6 +5,19 @@
 # SPDX-License-Identifier: MIT
 #
 
+"""Abstract base class for WireGuard device backends.
+
+This module defines :class:`WireguardDevice`, the backend-agnostic
+interface for reading and writing WireGuard interface configurations.
+Concrete implementations are provided by
+:mod:`wireguard_tools.wireguard_netlink` (Linux Netlink via pyroute2) and
+:mod:`wireguard_tools.wireguard_uapi` (userspace UAPI socket).
+
+The :meth:`WireguardDevice.get` and :meth:`WireguardDevice.list` class
+methods automatically select an appropriate backend at runtime, preferring
+the UAPI socket when available and falling back to Netlink.
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -16,29 +29,80 @@ if TYPE_CHECKING:
 
 
 class WireguardDevice(ABC):
+    """Abstract base for WireGuard device management.
+
+    Subclasses must implement :meth:`get_config` and :meth:`set_config`.
+    :meth:`sync_config` has a default implementation that delegates to
+    :meth:`set_config` but may be overridden for backends that support
+    incremental updates.
+
+    Use the :meth:`get` class method to obtain a backend-appropriate
+    device handle for a given interface name, or :meth:`list` to discover
+    all WireGuard interfaces on the system.
+
+    :param interface: Operating-system name of the WireGuard network
+        interface (e.g. ``"wg0"``).
+    """
+
     def __init__(self, interface: str) -> None:
         self.interface = interface
 
     def close(self) -> None:
+        """Release resources held by this device handle.
+
+        The default implementation is a no-op.  Subclasses that open file
+        descriptors or sockets should override this method.
+        """
         return None
 
     @abstractmethod
-    def get_config(self) -> WireguardConfig: ...
+    def get_config(self) -> WireguardConfig:
+        """Retrieve the current running configuration of the interface.
+
+        :returns: Snapshot of the active interface configuration and peer
+            state.
+        :rtype: WireguardConfig
+        """
+        ...
 
     @abstractmethod
     def set_config(self, config: WireguardConfig) -> None:
-        """Atomically replace the full interface configuration (setconf)."""
+        """Atomically replace the full interface configuration (setconf).
+
+        All existing peers are removed and replaced with those defined in
+        *config*.  Interface-level parameters (private key, listen port,
+        fwmark) are set unconditionally.
+
+        :param config: The desired complete interface configuration.
+        """
         ...
 
     def sync_config(self, config: WireguardConfig) -> None:
         """Diff against running config and apply only changes (syncconf).
 
-        Subclasses may override with an optimized implementation.
+        Unlike :meth:`set_config`, this method preserves peers that are
+        unchanged and only adds, removes, or updates those that differ.
+        Subclasses may override with an optimised implementation; the
+        default simply delegates to :meth:`set_config`.
+
+        :param config: The desired complete interface configuration.
         """
         self.set_config(config)
 
     @classmethod
     def get(cls, ifname: str) -> WireguardDevice:
+        """Obtain a device handle for the named interface.
+
+        Backend selection tries the UAPI userspace socket first
+        (:class:`~wireguard_tools.wireguard_uapi.WireguardUAPIDevice`) and
+        falls back to the Netlink backend
+        (:class:`~wireguard_tools.wireguard_netlink.WireguardNetlinkDevice`)
+        if the UAPI socket file is not found.
+
+        :param ifname: Interface name (e.g. ``"wg0"``).
+        :returns: A concrete device handle for the interface.
+        :rtype: WireguardDevice
+        """
         from .wireguard_netlink import WireguardNetlinkDevice
         from .wireguard_uapi import WireguardUAPIDevice
 
@@ -48,6 +112,14 @@ class WireguardDevice(ABC):
 
     @classmethod
     def list(cls) -> Iterator[WireguardDevice]:
+        """Discover all WireGuard interfaces on the system.
+
+        Yields devices from both the Netlink and UAPI backends.  Netlink
+        devices are yielded first, followed by UAPI devices.
+
+        :returns: Iterator of device handles.
+        :rtype: Iterator[WireguardDevice]
+        """
         from .wireguard_netlink import WireguardNetlinkDevice
         from .wireguard_uapi import WireguardUAPIDevice
 

--- a/src/wireguard_tools/wireguard_key.py
+++ b/src/wireguard_tools/wireguard_key.py
@@ -24,10 +24,24 @@ HEX_KEY_LENGTH = 64
 
 
 def convert_wireguard_key(value: str | bytes | WireguardKey) -> bytes:
-    """Decode a wireguard key to its byte string form.
+    """Decode a WireGuard key from various representations into raw bytes.
 
-    Accepts urlsafe encoded base64 keys with possibly missing padding.
-    Validates that the resulting key value is a 32-byte byte string.
+    Accept a key in one of several common formats and normalise it to a
+    32-byte ``bytes`` object suitable for cryptographic operations.
+
+    The following input types are handled:
+
+    * :class:`WireguardKey` — the existing ``keydata`` is returned directly.
+    * ``bytes`` — assumed to be the raw 32-byte key material.
+    * ``str`` of length 64 — decoded as a hexadecimal string.
+    * Any other ``str`` — decoded as URL-safe Base64 (missing ``=`` padding
+      is tolerated).
+
+    :param value: Key material in any of the accepted formats.
+    :type value: str | bytes | WireguardKey
+    :returns: The raw 32-byte key.
+    :rtype: bytes
+    :raises ValueError: If the decoded key is not exactly 32 bytes long.
     """
     if isinstance(value, WireguardKey):
         return value.keydata
@@ -48,39 +62,105 @@ def convert_wireguard_key(value: str | bytes | WireguardKey) -> bytes:
 
 @define(frozen=True)
 class WireguardKey:
-    """Representation of a WireGuard key."""
+    """Immutable representation of a WireGuard Curve25519 key.
+
+    This is an *attrs*-based frozen class that wraps 32 bytes of key
+    material.  Instances can be created from raw ``bytes``, hexadecimal
+    strings, Base64-encoded strings, or existing :class:`WireguardKey`
+    objects — the :func:`convert_wireguard_key` converter is applied
+    automatically by the constructor.
+
+    Being frozen, :class:`WireguardKey` is hashable and can be used as a
+    dictionary key or in sets.
+
+    :param keydata: Key material in any format accepted by
+        :func:`convert_wireguard_key`.
+    :type keydata: str | bytes | WireguardKey
+    """
 
     keydata: bytes = field(converter=convert_wireguard_key)
 
     @classmethod
     def generate(cls) -> WireguardKey:
-        """Generate a new private key."""
+        """Generate a new random Curve25519 private key.
+
+        Obtain 32 cryptographically-secure random bytes via
+        :func:`secrets.token_bytes` and clamp them into a valid
+        Curve25519 private scalar using
+        :meth:`X25519PrivateKey.from_private_bytes`.
+
+        :returns: A freshly generated private key.
+        :rtype: WireguardKey
+        """
         random_data = token_bytes(RAW_KEY_LENGTH)
         # turn it into a proper curve25519 private key by fixing/clamping the value
         private_bytes = X25519PrivateKey.from_private_bytes(random_data).private_bytes()
         return cls(private_bytes)
 
     def public_key(self) -> WireguardKey:
-        """Derive public key from private key."""
+        """Derive the Curve25519 public key from this private key.
+
+        Perform a scalar multiplication of the Curve25519 base point by
+        the private scalar stored in this key.
+
+        :returns: The corresponding public key.
+        :rtype: WireguardKey
+        """
         public_bytes = X25519PrivateKey.from_private_bytes(self.keydata).public_key()
         return WireguardKey(public_bytes)
 
     def __bool__(self) -> bool:
+        """Return whether the key contains non-zero data.
+
+        An all-zero key is treated as *falsy*, which is useful for
+        detecting unset or placeholder keys.
+
+        :returns: ``False`` if every byte is zero, ``True`` otherwise.
+        :rtype: bool
+        """
         return int.from_bytes(self.keydata, "little") != 0
 
     def __repr__(self) -> str:
+        """Return an unambiguous string that can recreate this key.
+
+        The format is ``WireguardKey('<base64>')`` so that it is both
+        human-readable and usable in ``eval()`` round-trips.
+
+        :returns: Evaluable representation of the key.
+        :rtype: str
+        """
         return f"WireguardKey('{self}')"
 
     def __str__(self) -> str:
-        """Return a base64 encoded representation of the key."""
+        """Return the standard (non-URL-safe) Base64 encoding of the key.
+
+        This is the canonical encoding used by ``wg(8)`` and WireGuard
+        configuration files.
+
+        :returns: Base64-encoded key string (44 characters, ``=`` padded).
+        :rtype: str
+        """
         return standard_b64encode(self.keydata).decode("utf-8")
 
     @property
     def urlsafe(self) -> str:
-        """Return a urlsafe base64 encoded representation of the key."""
+        """Return the URL-safe Base64 encoding of the key without padding.
+
+        Uses ``+`` → ``-`` and ``/`` → ``_`` substitutions per
+        :rfc:`4648` §5 and strips trailing ``=`` padding characters.
+
+        :returns: URL-safe Base64 key string with no ``=`` padding.
+        :rtype: str
+        """
         return urlsafe_b64encode(self.keydata).decode("utf-8").rstrip("=")
 
     @property
     def hex(self) -> str:
-        """Return a hexadecimal encoded representation of the key."""
+        """Return the lowercase hexadecimal encoding of the key.
+
+        The result is a 64-character string containing only ``[0-9a-f]``.
+
+        :returns: Hex-encoded key string.
+        :rtype: str
+        """
         return self.keydata.hex()

--- a/src/wireguard_tools/wireguard_netlink.py
+++ b/src/wireguard_tools/wireguard_netlink.py
@@ -5,6 +5,18 @@
 # SPDX-License-Identifier: MIT
 #
 
+"""Linux Netlink backend for managing WireGuard devices.
+
+This module provides :class:`WireguardNetlinkDevice`, a
+:class:`~wireguard_tools.wireguard_device.WireguardDevice` implementation
+that communicates with the WireGuard kernel module through the Netlink
+socket interface via `pyroute2 <https://pyroute2.org/>`_.
+
+.. note::
+
+   Netlink operations typically require ``CAP_NET_ADMIN`` privileges.
+"""
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -18,14 +30,40 @@ from .wireguard_key import WireguardKey
 
 
 class WireguardNetlinkDevice(WireguardDevice):
+    """WireGuard device backed by Linux Netlink (pyroute2).
+
+    Manages the lifecycle of a :class:`pyroute2.WireGuard` handle used
+    for all get/set operations on the named interface.  Callers should
+    invoke :meth:`close` (or use the device as a context manager via the
+    base class) when finished to release the Netlink socket.
+
+    :param interface: Name of the WireGuard network interface
+        (e.g. ``"wg0"``).
+    """
+
     def __init__(self, interface: str) -> None:
         super().__init__(interface)
         self.wg = pyroute2.WireGuard()
 
     def close(self) -> None:
+        """Close the underlying Netlink socket.
+
+        After this call, further operations on this device will fail.
+        """
         self.wg.close()
 
     def get_config(self) -> WireguardConfig:
+        """Retrieve the current WireGuard configuration from the kernel.
+
+        Queries the Netlink interface for private key, listen port, fwmark,
+        and all peer state including allowed IPs, endpoint, handshake time,
+        and transfer statistics.
+
+        :returns: Snapshot of the running interface configuration.
+        :rtype: WireguardConfig
+        :raises RuntimeError: If the interface cannot be accessed (e.g. it
+            does not exist or the caller lacks privileges).
+        """
         try:
             info = self.wg.info(self.interface)
             attrs = dict(info[0]["attrs"])
@@ -78,12 +116,38 @@ class WireguardNetlinkDevice(WireguardDevice):
         return wgconfig
 
     def set_config(self, config: WireguardConfig) -> None:
+        """Replace the interface configuration via Netlink.
+
+        Delegates to :meth:`_apply_config`, which diffs against the current
+        running state, removes stale peers, and updates or adds new ones.
+
+        :param config: Desired configuration to apply.
+        """
         self._apply_config(config)
 
     def sync_config(self, config: WireguardConfig) -> None:
+        """Synchronise the interface configuration via Netlink.
+
+        Functionally equivalent to :meth:`set_config` for the Netlink
+        backend — both diff against the running state before applying
+        changes.
+
+        :param config: Desired configuration to synchronise.
+        """
         self._apply_config(config)
 
     def _apply_config(self, config: WireguardConfig) -> None:
+        """Diff the desired configuration against running state and apply changes.
+
+        Reads the current device configuration, then:
+
+        1. Sets interface-level parameters (private key, listen port, fwmark).
+        2. Removes peers present in the current config but absent from *config*.
+        3. Updates peers whose settings have changed.
+        4. Adds peers that are new in *config*.
+
+        :param config: Desired full interface configuration.
+        """
         current_config = self.get_config()
 
         self.wg.set(
@@ -109,6 +173,16 @@ class WireguardNetlinkDevice(WireguardDevice):
             self.wg.set(self.interface, peer=self._wg_set_peer_arg(peer))
 
     def _wg_set_peer_arg(self, peer: WireguardPeer) -> dict[str, str | int | list[str]]:
+        """Build a pyroute2-compatible peer argument dictionary.
+
+        Translates a :class:`~wireguard_tools.wireguard_config.WireguardPeer`
+        into the dictionary format expected by :meth:`pyroute2.WireGuard.set`.
+
+        :param peer: Peer whose attributes are to be serialised.
+        :returns: Dictionary suitable for the ``peer`` keyword of
+            :meth:`pyroute2.WireGuard.set`.
+        :rtype: dict[str, str | int | list[str]]
+        """
         peer_dict: dict[str, str | int | list[str]] = {
             "public_key": str(peer.public_key),
         }
@@ -124,6 +198,14 @@ class WireguardNetlinkDevice(WireguardDevice):
 
     @classmethod
     def list(cls) -> Iterator[WireguardNetlinkDevice]:
+        """Yield all WireGuard interfaces discovered via Netlink.
+
+        Uses :class:`pyroute2.NDB` to enumerate network interfaces and
+        filters for those with ``kind == "wireguard"``.
+
+        :returns: Iterator of :class:`WireguardNetlinkDevice` instances.
+        :rtype: Iterator[WireguardNetlinkDevice]
+        """
         with pyroute2.NDB() as ndb:
             for nic in ndb.interfaces:
                 if nic.kind == "wireguard":

--- a/src/wireguard_tools/wireguard_netlink.py
+++ b/src/wireguard_tools/wireguard_netlink.py
@@ -78,9 +78,14 @@ class WireguardNetlinkDevice(WireguardDevice):
         return wgconfig
 
     def set_config(self, config: WireguardConfig) -> None:
+        self._apply_config(config)
+
+    def sync_config(self, config: WireguardConfig) -> None:
+        self._apply_config(config)
+
+    def _apply_config(self, config: WireguardConfig) -> None:
         current_config = self.get_config()
 
-        # set/update the configuration
         self.wg.set(
             interface=self.interface,
             private_key=str(config.private_key) if config.private_key else None,
@@ -91,17 +96,14 @@ class WireguardNetlinkDevice(WireguardDevice):
         cur_peers = set(current_config.peers)
         new_peers = set(config.peers)
 
-        # remove peers that are no longer in the configuration
         for key in cur_peers.difference(new_peers):
             self.wg.set(self.interface, peer={"public_key": str(key), "remove": True})
 
-        # update any changed peers
         for key in cur_peers.intersection(new_peers):
             peer = config.peers[key]
             if peer != current_config.peers[key]:
                 self.wg.set(self.interface, peer=self._wg_set_peer_arg(peer))
 
-        # add any new peers
         for key in new_peers.difference(cur_peers):
             peer = config.peers[key]
             self.wg.set(self.interface, peer=self._wg_set_peer_arg(peer))

--- a/src/wireguard_tools/wireguard_uapi.py
+++ b/src/wireguard_tools/wireguard_uapi.py
@@ -7,8 +7,10 @@
 
 from __future__ import annotations
 
+import os
 import socket
-from ipaddress import ip_address, ip_interface
+import time
+from ipaddress import IPv6Address, ip_address, ip_interface
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator
 
@@ -52,8 +54,10 @@ class WireguardUAPIDevice(WireguardDevice):
             # interface
             if key == "private_key":
                 config.private_key = WireguardKey(value)
-            elif key in ["listen_port", "fwmark"]:
-                setattr(config, key, int(value))
+            elif key == "listen_port":
+                config.listen_port = int(value)
+            elif key == "fwmark":
+                config.fwmark = int(value)
 
             # peer
             elif key == "public_key":
@@ -82,9 +86,12 @@ class WireguardUAPIDevice(WireguardDevice):
                 assert peer is not None
                 if peer.last_handshake is not None:
                     peer.last_handshake += int(value) * 1e-9
-            elif key in ["rx_bytes", "tx_bytes"]:
+            elif key == "rx_bytes":
                 assert peer is not None
-                setattr(peer, key, int(value))
+                peer.rx_bytes = int(value)
+            elif key == "tx_bytes":
+                assert peer is not None
+                peer.tx_bytes = int(value)
 
             # misc
             elif key == "protocol_version":
@@ -101,7 +108,80 @@ class WireguardUAPIDevice(WireguardDevice):
                     raise RuntimeError(msg)
         return config
 
+    @staticmethod
+    def _resolve_endpoint(peer: WireguardPeer) -> tuple[str, int] | None:
+        """Resolve a peer endpoint to an (ip, port) tuple, handling hostnames.
+
+        Respects WG_ENDPOINT_RESOLUTION_RETRIES (default 15) for transient
+        DNS failures, matching the behavior of the C wg(8) implementation.
+        """
+        if peer.endpoint_host is None or peer.endpoint_port is None:
+            return None
+        host = peer.endpoint_host
+        if isinstance(host, str):
+            retries_env = os.environ.get("WG_ENDPOINT_RESOLUTION_RETRIES", "15")
+            if retries_env == "infinity":
+                max_retries = float("inf")
+            else:
+                try:
+                    max_retries = int(retries_env)
+                except ValueError:
+                    max_retries = 15
+            attempt = 0
+            while True:
+                try:
+                    infos = socket.getaddrinfo(
+                        host, peer.endpoint_port, type=socket.SOCK_DGRAM
+                    )
+                    if infos:
+                        host = infos[0][4][0]
+                        break
+                except socket.gaierror:
+                    pass
+                attempt += 1
+                if attempt > max_retries:
+                    msg = f"Unable to resolve endpoint: {host}"
+                    raise RuntimeError(msg)
+                time.sleep(min(attempt * 0.25, 5.0))
+        return str(host), peer.endpoint_port
+
+    def _build_peer_uapi(self, peer: WireguardPeer) -> list[str]:
+        """Build UAPI lines for a single peer."""
+        lines = [f"public_key={peer.public_key.hex}"]
+        endpoint = self._resolve_endpoint(peer)
+        if endpoint is not None:
+            host_str = endpoint[0]
+            try:
+                if isinstance(IPv6Address(host_str), IPv6Address):
+                    host_str = f"[{host_str}]"
+            except ValueError:
+                pass
+            lines.append(f"endpoint={host_str}:{endpoint[1]}")
+        if peer.preshared_key is not None:
+            lines.append(f"preshared_key={peer.preshared_key.hex}")
+        if peer.persistent_keepalive is not None:
+            lines.append(
+                f"persistent_keepalive_interval={peer.persistent_keepalive}",
+            )
+        lines.append("replace_allowed_ips=true")
+        lines.extend(f"allowed_ip={address}" for address in peer.allowed_ips)
+        return lines
+
+    def _send_uapi_set(self, uapi: list[str]) -> None:
+        """Send a UAPI set message and check the response."""
+        uapi.append("\n")
+        self.uapi_socket.sendall("\n".join(uapi).encode())
+        response = self._recvmsg()
+        if not response or response[0][0] != "errno":
+            msg = "WireguardUAPIDevice: unexpected UAPI response"
+            raise RuntimeError(msg)
+        errno = int(response[0][1])
+        if errno != 0:
+            msg = f"WireguardUAPIDevice: set failed with errno {errno}"
+            raise RuntimeError(msg)
+
     def set_config(self, config: WireguardConfig) -> None:
+        """Atomically replace the full config (setconf semantics)."""
         uapi = ["set=1"]
         if config.private_key is not None:
             uapi.append(f"private_key={config.private_key.hex}")
@@ -112,34 +192,37 @@ class WireguardUAPIDevice(WireguardDevice):
 
         uapi.append("replace_peers=true")
         for peer in config.peers.values():
-            # should resolve hostname for endpoint here
-            assert not isinstance(peer.endpoint_host, str)
-            uapi.extend(
-                [
-                    f"public_key={peer.public_key.hex}",
-                    f"endpoint={peer.endpoint_host}:{peer.endpoint_port}",
-                ],
-            )
-            if peer.preshared_key is not None:
-                uapi.append(f"preshared_key={peer.preshared_key}")
-            if peer.persistent_keepalive is not None:
-                uapi.append(
-                    f"persistent_keepalive_interval={peer.persistent_keepalive}",
-                )
+            uapi.extend(self._build_peer_uapi(peer))
 
-            uapi.append("replace_allowed_ips=true")
-            uapi.extend([f"allowed_ip={address}" for address in peer.allowed_ips])
+        self._send_uapi_set(uapi)
 
-        uapi.append("\n")
-        self.uapi_socket.sendall("\n".join(uapi).encode())
+    def sync_config(self, config: WireguardConfig) -> None:
+        """Diff against running config and apply only changes (syncconf semantics)."""
+        current = self.get_config()
 
-        response = self._recvmsg()
-        assert len(response) == 1
-        assert response[0][0] == "errno"
-        errno = int(response[0][1])
-        if errno != 0:
-            msg = f"WireguardUAPIDevice.set_config failed with {errno}"
-            raise RuntimeError(msg)
+        uapi = ["set=1"]
+        if config.private_key is not None:
+            uapi.append(f"private_key={config.private_key.hex}")
+        if config.listen_port is not None:
+            uapi.append(f"listen_port={config.listen_port}")
+        if config.fwmark is not None:
+            uapi.append(f"fwmark={config.fwmark}")
+
+        cur_keys = set(current.peers)
+        new_keys = set(config.peers)
+
+        for key in cur_keys - new_keys:
+            uapi.append(f"public_key={key.hex}")
+            uapi.append("remove=true")
+
+        for key in new_keys:
+            new_peer = config.peers[key]
+            old_peer = current.peers.get(key)
+            if old_peer is not None and old_peer == new_peer:
+                continue
+            uapi.extend(self._build_peer_uapi(new_peer))
+
+        self._send_uapi_set(uapi)
 
     # a wireguard UAPI response message is a series of key=value lines
     # followed by an empty line

--- a/src/wireguard_tools/wireguard_uapi.py
+++ b/src/wireguard_tools/wireguard_uapi.py
@@ -5,6 +5,22 @@
 # SPDX-License-Identifier: MIT
 #
 
+"""WireGuard userspace API (UAPI) device interface.
+
+Communicate with WireGuard interfaces through the UAPI Unix-domain socket
+protocol described in the `wireguard.h` header.  Each
+:class:`WireguardUAPIDevice` instance owns a ``SOCK_STREAM`` connection to
+``/var/run/wireguard/<iface>.sock`` and exposes ``get``, ``set``, and ``sync``
+operations that translate between :class:`~.wireguard_config.WireguardConfig`
+objects and the UAPI key=value wire format.
+
+Typical usage::
+
+    from contextlib import closing
+    with closing(WireguardUAPIDevice("wg0")) as dev:
+        cfg = dev.get_config()
+"""
+
 from __future__ import annotations
 
 import os
@@ -25,7 +41,33 @@ WG_UAPI_SOCKET_DIR = Path("/var/run/wireguard")
 
 
 class WireguardUAPIDevice(WireguardDevice):
+    """WireGuard device controlled through the userspace API socket.
+
+    The instance connects to the UAPI Unix socket at construction time and
+    retains the connection for the lifetime of the object.  Callers **must**
+    call :meth:`close` (or use :func:`contextlib.closing`) to release the
+    underlying file descriptor.
+
+    The UAPI protocol is a simple newline-delimited ``key=value`` text
+    format transmitted over a ``SOCK_STREAM`` Unix socket located under
+    :data:`WG_UAPI_SOCKET_DIR`.  A ``get`` request consists of the line
+    ``get=1\\n\\n``; a ``set`` request begins with ``set=1\\n`` followed by
+    interface and peer fields, terminated by a blank line.
+
+    :param uapi_path: Interface name (e.g. ``"wg0"``) or an absolute path to
+        the UAPI socket file.
+    """
+
     def __init__(self, uapi_path: str | os.PathLike[str]) -> None:
+        """Open a UAPI connection to a WireGuard interface.
+
+        When *uapi_path* is a plain string the socket is looked up as
+        ``/var/run/wireguard/<uapi_path>.sock``.  An :class:`os.PathLike`
+        value is used verbatim.
+
+        :param uapi_path: Interface name or absolute socket path.
+        :raises FileNotFoundError: If the socket file does not exist.
+        """
         self.uapi_path = (
             WG_UAPI_SOCKET_DIR.joinpath(uapi_path).with_suffix(".sock")
             if isinstance(uapi_path, str)
@@ -42,9 +84,27 @@ class WireguardUAPIDevice(WireguardDevice):
         self._buffer = ""
 
     def close(self) -> None:
+        """Close the underlying UAPI Unix socket.
+
+        After calling this method the device object must not be reused.
+        Calling :meth:`close` on an already-closed device is safe (the
+        socket's own ``close`` is idempotent).
+        """
         self.uapi_socket.close()
 
     def get_config(self) -> WireguardConfig:
+        """Retrieve the current interface configuration via UAPI ``get``.
+
+        Send a ``get=1`` request over the socket and parse the key=value
+        response into a :class:`~.wireguard_config.WireguardConfig`,
+        including all peer entries and device statistics such as
+        ``last_handshake``, ``rx_bytes``, and ``tx_bytes``.
+
+        :returns: Parsed configuration snapshot of the running interface.
+        :rtype: WireguardConfig
+        :raises RuntimeError: If the UAPI response carries a non-zero
+            ``errno`` or an unexpected ``protocol_version``.
+        """
         self.uapi_socket.sendall(b"get=1\n\n")
         response = self._recvmsg()
 
@@ -110,10 +170,26 @@ class WireguardUAPIDevice(WireguardDevice):
 
     @staticmethod
     def _resolve_endpoint(peer: WireguardPeer) -> tuple[str, int] | None:
-        """Resolve a peer endpoint to an (ip, port) tuple, handling hostnames.
+        """Resolve a peer endpoint to an ``(ip, port)`` tuple.
 
-        Respects WG_ENDPOINT_RESOLUTION_RETRIES (default 15) for transient
-        DNS failures, matching the behavior of the C wg(8) implementation.
+        If the endpoint host is already an IP address it is returned directly.
+        When the host is a DNS name, the method performs ``getaddrinfo`` with
+        retries to tolerate transient resolution failures, matching the
+        behaviour of the C ``wg(8)`` implementation.
+
+        The maximum number of retries is controlled by the
+        ``WG_ENDPOINT_RESOLUTION_RETRIES`` environment variable (default
+        ``15``).  The special value ``"infinity"`` retries forever.  Back-off
+        between attempts grows linearly (``attempt * 0.25 s``, capped at
+        ``5 s``).
+
+        :param peer: Peer whose :attr:`endpoint_host` and
+            :attr:`endpoint_port` are to be resolved.
+        :returns: ``(ip_string, port)`` tuple, or ``None`` when the peer has
+            no endpoint configured.
+        :rtype: tuple[str, int] | None
+        :raises RuntimeError: If DNS resolution fails after exhausting all
+            retries.
         """
         if peer.endpoint_host is None or peer.endpoint_port is None:
             return None
@@ -146,7 +222,21 @@ class WireguardUAPIDevice(WireguardDevice):
         return str(host), peer.endpoint_port
 
     def _build_peer_uapi(self, peer: WireguardPeer) -> list[str]:
-        """Build UAPI lines for a single peer."""
+        """Build UAPI ``set`` key=value lines for a single peer.
+
+        Produce the ordered sequence of UAPI fields that describe *peer*:
+        ``public_key``, optional ``endpoint``, optional ``preshared_key``,
+        optional ``persistent_keepalive_interval``, and the full
+        ``allowed_ip`` list (preceded by ``replace_allowed_ips=true``).
+
+        IPv6 endpoint addresses are enclosed in brackets as required by the
+        wire format.  Endpoint hostnames are resolved via
+        :meth:`_resolve_endpoint` before serialisation.
+
+        :param peer: Peer to serialise.
+        :returns: List of ``key=value`` strings (without trailing newlines).
+        :rtype: list[str]
+        """
         lines = [f"public_key={peer.public_key.hex}"]
         endpoint = self._resolve_endpoint(peer)
         if endpoint is not None:
@@ -168,7 +258,22 @@ class WireguardUAPIDevice(WireguardDevice):
         return lines
 
     def _send_uapi_set(self, uapi: list[str]) -> None:
-        """Send a UAPI set message and check the response."""
+        """Send a UAPI ``set`` message and verify success.
+
+        Join the *uapi* lines with newlines, append a blank-line terminator,
+        and transmit the payload over the socket.  The response is expected to
+        be a single ``errno=<n>`` line; any other response shape or a non-zero
+        errno raises :class:`RuntimeError`.
+
+        .. note::
+           This method **mutates** *uapi* by appending an empty trailing
+           element used as the blank-line terminator.
+
+        :param uapi: Ordered UAPI key=value lines (must already begin with
+            ``set=1``).
+        :raises RuntimeError: If the response is malformed or carries a
+            non-zero errno.
+        """
         uapi.append("\n")
         self.uapi_socket.sendall("\n".join(uapi).encode())
         response = self._recvmsg()
@@ -181,7 +286,17 @@ class WireguardUAPIDevice(WireguardDevice):
             raise RuntimeError(msg)
 
     def set_config(self, config: WireguardConfig) -> None:
-        """Atomically replace the full config (setconf semantics)."""
+        """Replace the full interface configuration (``setconf`` semantics).
+
+        Build a UAPI ``set`` payload that writes the interface-level fields
+        (``private_key``, ``listen_port``, ``fwmark``) and then all peers with
+        ``replace_peers=true``, effectively discarding any peers not present
+        in *config*.
+
+        :param config: Desired configuration to apply.
+        :raises RuntimeError: If the kernel rejects the configuration (the
+            UAPI response carries a non-zero errno).
+        """
         uapi = ["set=1"]
         if config.private_key is not None:
             uapi.append(f"private_key={config.private_key.hex}")
@@ -197,7 +312,24 @@ class WireguardUAPIDevice(WireguardDevice):
         self._send_uapi_set(uapi)
 
     def sync_config(self, config: WireguardConfig) -> None:
-        """Diff against running config and apply only changes (syncconf semantics)."""
+        """Synchronise the running configuration with *config* (``syncconf`` semantics).
+
+        Fetch the current interface state via :meth:`get_config`, compute the
+        diff, and emit only the necessary UAPI operations:
+
+        * Peers present in the running config but absent from *config* are
+          removed (``remove=true``).
+        * Peers that are new or differ from the running config are
+          (re-)applied via :meth:`_build_peer_uapi`.
+        * Unchanged peers are left untouched, preserving handshake state and
+          traffic counters.
+
+        Interface-level fields (``private_key``, ``listen_port``, ``fwmark``)
+        are always written when set on *config*.
+
+        :param config: Desired target configuration.
+        :raises RuntimeError: If the kernel rejects the update.
+        """
         current = self.get_config()
 
         uapi = ["set=1"]
@@ -227,6 +359,18 @@ class WireguardUAPIDevice(WireguardDevice):
     # a wireguard UAPI response message is a series of key=value lines
     # followed by an empty line
     def _recvmsg(self) -> list[tuple[str, str]]:
+        """Read a complete UAPI response message from the socket.
+
+        The UAPI wire protocol delimits messages with a blank line.  This
+        method reads from the socket (using an internal buffer to handle
+        partial reads) until the blank-line terminator is encountered, then
+        splits each line on the first ``=`` into ``(key, value)`` pairs.
+
+        :returns: Ordered list of ``(key, value)`` tuples comprising the
+            response.  An empty list is returned when the peer sends an
+            immediate blank line.
+        :rtype: list[tuple[str, str]]
+        """
         message = []
         while True:
             # read until we have at least a line
@@ -241,5 +385,14 @@ class WireguardUAPIDevice(WireguardDevice):
 
     @classmethod
     def list(cls) -> Iterator[WireguardUAPIDevice]:
+        """Discover all WireGuard interfaces with active UAPI sockets.
+
+        Glob ``/var/run/wireguard/*.sock`` and yield one connected
+        :class:`WireguardUAPIDevice` per socket file found.
+
+        :returns: Iterator of open device instances.  Callers are responsible
+            for closing each device.
+        :rtype: Iterator[WireguardUAPIDevice]
+        """
         for socket_path in WG_UAPI_SOCKET_DIR.glob("*.sock"):
             yield cls(socket_path.stem)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,9 +1,13 @@
 # Tests for CLI command parsing and logic.
 # SPDX-License-Identifier: MIT
 
+import argparse
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from wireguard_tools.cli import SHOW_FIELDS, _parse_set_args, _resolve_show_args
+from wireguard_tools.cli import SHOW_FIELDS, _parse_set_args, _resolve_show_args, set_
+from wireguard_tools.wireguard_config import WireguardConfig
 from wireguard_tools.wireguard_key import WireguardKey
 
 
@@ -194,3 +198,20 @@ class TestResolveShowArgs:
     def test_invalid_field_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown field"):
             _resolve_show_args(["wg0", "not-a-field"])
+
+
+class TestSetCommand:
+    @pytest.mark.parametrize("fwmark_token", ["off", "0"])
+    def test_set_fwmark_zero_is_preserved(self, fwmark_token: str) -> None:
+        config = WireguardConfig()
+        config.fwmark = 123
+        fake_device = MagicMock()
+        fake_device.get_config.return_value = config
+
+        args = argparse.Namespace(remaining=["wg0", "fwmark", fwmark_token])
+        with patch("wireguard_tools.cli.WireguardDevice.get", return_value=fake_device):
+            result = set_(args)
+
+        assert result == 0
+        assert config.fwmark == 0
+        fake_device.set_config.assert_called_once_with(config)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from wireguard_tools.cli import SHOW_FIELDS, _parse_set_args
+from wireguard_tools.cli import SHOW_FIELDS, _parse_set_args, _resolve_show_args
 from wireguard_tools.wireguard_key import WireguardKey
 
 
@@ -82,6 +82,15 @@ class TestParseSetArgs:
         )
         assert len(peers[0]["allowed_ips"]) == 2
         assert peers[0]["replace_allowed_ips"] is True
+
+    def test_peer_allowed_ips_replace_ignores_empty_entries(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(
+            ["wg0", "peer", key, "allowed-ips", "10.0.0.0/24,,10.1.0.0/24"]
+        )
+        assert len(peers[0]["allowed_ips"]) == 2
+        assert str(peers[0]["allowed_ips"][0]) == "10.0.0.0/24"
+        assert str(peers[0]["allowed_ips"][1]) == "10.1.0.0/24"
 
     def test_peer_allowed_ips_empty_clears(self) -> None:
         key = str(WireguardKey.generate())
@@ -163,3 +172,25 @@ class TestShowFields:
             "dump",
         }
         assert set(SHOW_FIELDS) == expected
+
+
+class TestResolveShowArgs:
+    def test_no_args(self) -> None:
+        assert _resolve_show_args([]) == (None, None)
+
+    def test_single_interface(self) -> None:
+        assert _resolve_show_args(["wg0"]) == ("wg0", None)
+
+    def test_single_field_targets_all_interfaces(self) -> None:
+        assert _resolve_show_args(["public-key"]) == (None, "public-key")
+
+    def test_interface_and_field(self) -> None:
+        assert _resolve_show_args(["wg0", "public-key"]) == ("wg0", "public-key")
+
+    def test_too_many_args_raises(self) -> None:
+        with pytest.raises(ValueError, match="Usage: wg show"):
+            _resolve_show_args(["wg0", "public-key", "extra"])
+
+    def test_invalid_field_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown field"):
+            _resolve_show_args(["wg0", "not-a-field"])

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,165 @@
+# Tests for CLI command parsing and logic.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from wireguard_tools.cli import SHOW_FIELDS, _parse_set_args
+from wireguard_tools.wireguard_key import WireguardKey
+
+
+class TestParseSetArgs:
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_set_args([])
+
+    def test_interface_only(self) -> None:
+        iface, params, peers = _parse_set_args(["wg0"])
+        assert iface == "wg0"
+        assert params == {}
+        assert peers == []
+
+    def test_listen_port(self) -> None:
+        _, params, _ = _parse_set_args(["wg0", "listen-port", "51820"])
+        assert params["listen_port"] == 51820
+
+    def test_fwmark_decimal(self) -> None:
+        _, params, _ = _parse_set_args(["wg0", "fwmark", "51820"])
+        assert params["fwmark"] == 51820
+
+    def test_fwmark_hex(self) -> None:
+        _, params, _ = _parse_set_args(["wg0", "fwmark", "0xca6c"])
+        assert params["fwmark"] == 0xCA6C
+
+    def test_fwmark_off(self) -> None:
+        _, params, _ = _parse_set_args(["wg0", "fwmark", "off"])
+        assert params["fwmark"] == 0
+
+    def test_peer_basic(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(["wg0", "peer", key])
+        assert len(peers) == 1
+        assert str(peers[0]["public_key"]) == key
+
+    def test_peer_remove(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(["wg0", "peer", key, "remove"])
+        assert peers[0]["remove"] is True
+
+    def test_peer_endpoint(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(
+            ["wg0", "peer", key, "endpoint", "10.0.0.1:51820"]
+        )
+        assert peers[0]["endpoint_host"] == "10.0.0.1"
+        assert peers[0]["endpoint_port"] == 51820
+
+    def test_peer_ipv6_endpoint(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(
+            ["wg0", "peer", key, "endpoint", "[::1]:51820"]
+        )
+        assert peers[0]["endpoint_host"] == "::1"
+        assert peers[0]["endpoint_port"] == 51820
+
+    def test_peer_persistent_keepalive(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(
+            ["wg0", "peer", key, "persistent-keepalive", "25"]
+        )
+        assert peers[0]["persistent_keepalive"] == 25
+
+    def test_peer_persistent_keepalive_off(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(
+            ["wg0", "peer", key, "persistent-keepalive", "off"]
+        )
+        assert peers[0]["persistent_keepalive"] == 0
+
+    def test_peer_allowed_ips_replace(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(
+            ["wg0", "peer", key, "allowed-ips", "10.0.0.0/24,10.1.0.0/24"]
+        )
+        assert len(peers[0]["allowed_ips"]) == 2
+        assert peers[0]["replace_allowed_ips"] is True
+
+    def test_peer_allowed_ips_empty_clears(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(["wg0", "peer", key, "allowed-ips", ""])
+        assert peers[0]["allowed_ips"] == []
+        assert peers[0]["replace_allowed_ips"] is True
+
+    def test_peer_allowed_ips_incremental(self) -> None:
+        key = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(
+            ["wg0", "peer", key, "allowed-ips", "+10.0.0.0/24,-10.1.0.0/24"]
+        )
+        assert len(peers[0]["add_allowed_ips"]) == 1
+        assert len(peers[0]["remove_allowed_ips"]) == 1
+        assert str(peers[0]["add_allowed_ips"][0]) == "10.0.0.0/24"
+
+    def test_multiple_peers(self) -> None:
+        k1 = str(WireguardKey.generate())
+        k2 = str(WireguardKey.generate())
+        _, _, peers = _parse_set_args(
+            [
+                "wg0",
+                "peer",
+                k1,
+                "allowed-ips",
+                "10.0.0.0/24",
+                "peer",
+                k2,
+                "allowed-ips",
+                "10.1.0.0/24",
+            ]
+        )
+        assert len(peers) == 2
+
+    def test_interface_params_and_peers_combined(self) -> None:
+        key = str(WireguardKey.generate())
+        iface, params, peers = _parse_set_args(
+            [
+                "wg0",
+                "listen-port",
+                "51820",
+                "peer",
+                key,
+                "endpoint",
+                "10.0.0.1:51820",
+            ]
+        )
+        assert iface == "wg0"
+        assert params["listen_port"] == 51820
+        assert len(peers) == 1
+
+    def test_unknown_option_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown option"):
+            _parse_set_args(["wg0", "bogus-option"])
+
+    def test_remove_without_peer_raises(self) -> None:
+        with pytest.raises(ValueError, match="must follow"):
+            _parse_set_args(["wg0", "remove"])
+
+    def test_endpoint_without_peer_raises(self) -> None:
+        with pytest.raises(ValueError, match="must follow"):
+            _parse_set_args(["wg0", "endpoint", "10.0.0.1:51820"])
+
+
+class TestShowFields:
+    def test_all_expected_fields_present(self) -> None:
+        expected = {
+            "public-key",
+            "private-key",
+            "listen-port",
+            "fwmark",
+            "peers",
+            "preshared-keys",
+            "endpoints",
+            "allowed-ips",
+            "latest-handshakes",
+            "persistent-keepalive",
+            "transfer",
+            "dump",
+        }
+        assert set(SHOW_FIELDS) == expected

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -1,0 +1,217 @@
+# Tests for config parsing enhancements: IPv6 endpoints, FwMark hex,
+# AllowedIPs separators, Table/SaveConfig, and round-trip fidelity.
+# SPDX-License-Identifier: MIT
+
+from io import StringIO
+
+import pytest
+
+from wireguard_tools.wireguard_config import (
+    WireguardConfig,
+    WireguardPeer,
+    _parse_endpoint,
+    _split_comma_list,
+)
+from wireguard_tools.wireguard_key import WireguardKey
+
+
+class TestParseEndpoint:
+    def test_ipv4(self) -> None:
+        host, port = _parse_endpoint("192.168.1.1:51820")
+        assert host == "192.168.1.1"
+        assert port == 51820
+
+    def test_ipv6_bracket(self) -> None:
+        host, port = _parse_endpoint("[2607:5300:60:6b0::c05f:543]:2468")
+        assert host == "2607:5300:60:6b0::c05f:543"
+        assert port == 2468
+
+    def test_hostname(self) -> None:
+        host, port = _parse_endpoint("vpn.example.com:51820")
+        assert host == "vpn.example.com"
+        assert port == 51820
+
+
+class TestSplitCommaList:
+    def test_comma_space(self) -> None:
+        assert _split_comma_list("a, b, c") == ["a", "b", "c"]
+
+    def test_comma_no_space(self) -> None:
+        assert _split_comma_list("a,b,c") == ["a", "b", "c"]
+
+    def test_mixed_whitespace(self) -> None:
+        assert _split_comma_list("a ,b, c , d") == ["a", "b", "c", "d"]
+
+    def test_single(self) -> None:
+        assert _split_comma_list("10.0.0.1/32") == ["10.0.0.1/32"]
+
+    def test_trailing_comma(self) -> None:
+        assert _split_comma_list("a,b,") == ["a", "b"]
+
+    def test_double_comma(self) -> None:
+        assert _split_comma_list("a,,b") == ["a", "b"]
+
+    def test_empty_string(self) -> None:
+        assert _split_comma_list("") == []
+
+
+IPV6_CONFIG = """\
+[Interface]
+PrivateKey = DnLEmfJzVoCRJYXzdSXIhTqnjygnhh6O+I3ErMS6OUg=
+ListenPort = 51820
+
+[Peer]
+PublicKey = ba8AwcolBVDuhR/MKFU8O6CZrAjh7c20h6EOnQx0VRE=
+Endpoint = [2607:5300:60:6b0::c05f:543]:2468
+AllowedIPs = 10.0.0.1/32
+"""
+
+FWMARK_HEX_CONFIG = """\
+[Interface]
+PrivateKey = DnLEmfJzVoCRJYXzdSXIhTqnjygnhh6O+I3ErMS6OUg=
+FwMark = 0xca6c
+"""
+
+COMMA_NOSPACE_CONFIG = """\
+[Interface]
+PrivateKey = DnLEmfJzVoCRJYXzdSXIhTqnjygnhh6O+I3ErMS6OUg=
+
+[Peer]
+PublicKey = ba8AwcolBVDuhR/MKFU8O6CZrAjh7c20h6EOnQx0VRE=
+AllowedIPs = 10.0.0.1/32,10.0.0.2/32,10.0.0.3/32
+"""
+
+TABLE_SAVECONFIG = """\
+[Interface]
+PrivateKey = DnLEmfJzVoCRJYXzdSXIhTqnjygnhh6O+I3ErMS6OUg=
+ListenPort = 51820
+MTU = 1420
+Table = 1234
+SaveConfig = true
+Address = 10.0.0.1/24
+"""
+
+
+class TestIPv6EndpointConfig:
+    def test_parse_ipv6_endpoint(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(IPV6_CONFIG))
+        peer = list(config.peers.values())[0]
+        assert str(peer.endpoint_host) == "2607:5300:60:6b0::c05f:543"
+        assert peer.endpoint_port == 2468
+
+    def test_roundtrip_ipv6_endpoint(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(IPV6_CONFIG))
+        output = config.to_wgconfig()
+        assert "[2607:5300:60:6b0::c05f:543]:2468" in output
+
+    def test_reparsed_ipv6_endpoint(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(IPV6_CONFIG))
+        output = config.to_wgconfig()
+        config2 = WireguardConfig.from_wgconfig(StringIO(output))
+        peer2 = list(config2.peers.values())[0]
+        assert str(peer2.endpoint_host) == "2607:5300:60:6b0::c05f:543"
+        assert peer2.endpoint_port == 2468
+
+
+class TestFwMarkHex:
+    def test_parse_hex_fwmark(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(FWMARK_HEX_CONFIG))
+        assert config.fwmark == 0xCA6C
+
+    def test_parse_decimal_fwmark(self) -> None:
+        decimal = FWMARK_HEX_CONFIG.replace("0xca6c", "51820")
+        config = WireguardConfig.from_wgconfig(StringIO(decimal))
+        assert config.fwmark == 51820
+
+
+class TestAllowedIPsSeparator:
+    def test_comma_without_space(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(COMMA_NOSPACE_CONFIG))
+        peer = list(config.peers.values())[0]
+        assert len(peer.allowed_ips) == 3
+        assert str(peer.allowed_ips[0]) == "10.0.0.1/32"
+        assert str(peer.allowed_ips[2]) == "10.0.0.3/32"
+
+
+class TestTableAndSaveConfig:
+    def test_parse_table(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(TABLE_SAVECONFIG))
+        assert config.table == "1234"
+
+    def test_parse_save_config(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(TABLE_SAVECONFIG))
+        assert config.saveconfig is True
+
+    def test_emit_table_and_save_config(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(TABLE_SAVECONFIG))
+        output = config.to_wgconfig(wgquick_format=True)
+        assert "Table = 1234" in output
+        assert "SaveConfig = true" in output
+
+    def test_table_off(self) -> None:
+        text = TABLE_SAVECONFIG.replace("Table = 1234", "Table = off")
+        config = WireguardConfig.from_wgconfig(StringIO(text))
+        assert config.table == "off"
+
+    def test_table_auto(self) -> None:
+        text = TABLE_SAVECONFIG.replace("Table = 1234", "Table = auto")
+        config = WireguardConfig.from_wgconfig(StringIO(text))
+        assert config.table == "auto"
+
+    def test_save_config_false(self) -> None:
+        text = TABLE_SAVECONFIG.replace("SaveConfig = true", "SaveConfig = false")
+        config = WireguardConfig.from_wgconfig(StringIO(text))
+        assert config.saveconfig is False
+
+    def test_not_emitted_in_non_wgquick(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(TABLE_SAVECONFIG))
+        output = config.to_wgconfig(wgquick_format=False)
+        assert "Table" not in output
+        assert "SaveConfig" not in output
+
+
+class TestPeerFromDict:
+    def test_ipv6_endpoint_from_dict(self) -> None:
+        d = {
+            "public_key": "ba8AwcolBVDuhR/MKFU8O6CZrAjh7c20h6EOnQx0VRE=",
+            "endpoint": "[::1]:51820",
+            "allowed_ips": ["10.0.0.1/32"],
+        }
+        peer = WireguardPeer.from_dict(d)
+        assert str(peer.endpoint_host) == "::1"
+        assert peer.endpoint_port == 51820
+
+
+class TestConfigFromDict:
+    def test_full_roundtrip(self) -> None:
+        d = {
+            "private_key": "DnLEmfJzVoCRJYXzdSXIhTqnjygnhh6O+I3ErMS6OUg=",
+            "listen_port": 51820,
+            "addresses": ["10.0.0.1/24"],
+            "dns": ["1.1.1.1", "example.local"],
+            "peers": [
+                {
+                    "public_key": "ba8AwcolBVDuhR/MKFU8O6CZrAjh7c20h6EOnQx0VRE=",
+                    "endpoint": "192.168.1.1:51820",
+                    "allowed_ips": ["10.0.0.0/24"],
+                    "persistent_keepalive": 25,
+                },
+            ],
+        }
+        config = WireguardConfig.from_dict(d)
+        output = config.to_wgconfig(wgquick_format=True)
+        config2 = WireguardConfig.from_wgconfig(StringIO(output))
+        assert len(config2.peers) == 1
+        assert config2.listen_port == 51820
+        assert len(config2.dns_servers) == 1
+        assert len(config2.search_domains) == 1
+
+
+class TestMultipleInterfaceSections:
+    def test_raises_on_duplicate_interface(self) -> None:
+        bad = (
+            "[Interface]\nPrivateKey = DnLEmfJzVoCRJYXzdSXIhTqnjygnhh6O+I3ErMS6OUg=\n"
+            "\n[Interface]\nListenPort = 51820\n"
+        )
+        with pytest.raises(ValueError, match="More than one"):
+            WireguardConfig.from_wgconfig(StringIO(bad))

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,214 @@
+# Tests for the wg-daemon JSON-over-Unix-socket protocol
+#
+# All privileged operations (wg_quick, WireguardDevice) are mocked so
+# these tests run without root.
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import tempfile
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wireguard_tools.daemon import DaemonHandler, ThreadedUnixServer, serve
+from wireguard_tools.daemon_client import DaemonError, WgDaemonClient
+
+
+@pytest.fixture()
+def daemon_socket(tmp_path):
+    """Start a real daemon on a temp socket and yield its path."""
+    sock_path = str(tmp_path / "test-wg-daemon.sock")
+
+    server = ThreadedUnixServer(sock_path, DaemonHandler)
+    os.chmod(sock_path, 0o660)
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    yield sock_path
+
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.fixture()
+def client(daemon_socket):
+    return WgDaemonClient(socket_path=daemon_socket)
+
+
+def _raw_request(sock_path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Send a raw JSON request and read the response."""
+    raw = json.dumps(payload) + "\n"
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        s.connect(sock_path)
+        s.sendall(raw.encode())
+        s.shutdown(socket.SHUT_WR)
+        chunks = []
+        while True:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    finally:
+        s.close()
+    return json.loads(b"".join(chunks).decode())
+
+
+class TestProtocol:
+    """Test the wire protocol directly."""
+
+    def test_unknown_command(self, daemon_socket):
+        resp = _raw_request(daemon_socket, {"cmd": "nonexistent", "args": {}})
+        assert resp["ok"] is False
+        assert "Unknown command" in resp["error"]
+
+    def test_invalid_json(self, daemon_socket):
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            s.connect(daemon_socket)
+            s.sendall(b"not valid json\n")
+            s.shutdown(socket.SHUT_WR)
+            chunks = []
+            while True:
+                chunk = s.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        finally:
+            s.close()
+        resp = json.loads(b"".join(chunks).decode())
+        assert resp["ok"] is False
+        assert "Invalid request" in resp["error"]
+
+    def test_missing_cmd(self, daemon_socket):
+        resp = _raw_request(daemon_socket, {"args": {}})
+        assert resp["ok"] is False
+        assert "Unknown command" in resp["error"]
+
+
+class TestUpDown:
+    @patch("wireguard_tools.daemon.up")
+    def test_up_success(self, mock_up, client):
+        mock_up.return_value = None
+        client.up("wg0")
+        mock_up.assert_called_once_with("wg0")
+
+    @patch("wireguard_tools.daemon.up")
+    def test_up_missing_interface(self, mock_up, daemon_socket):
+        resp = _raw_request(daemon_socket, {"cmd": "up", "args": {}})
+        assert resp["ok"] is False
+        assert "interface" in resp["error"].lower()
+        mock_up.assert_not_called()
+
+    @patch("wireguard_tools.daemon.up")
+    def test_up_failure(self, mock_up, client):
+        mock_up.side_effect = RuntimeError("Interface wg0 already exists")
+        with pytest.raises(DaemonError, match="already exists"):
+            client.up("wg0")
+
+    @patch("wireguard_tools.daemon.down")
+    def test_down_success(self, mock_down, client):
+        mock_down.return_value = None
+        client.down("wg0")
+        mock_down.assert_called_once_with("wg0")
+
+
+class TestShow:
+    @patch("wireguard_tools.daemon.WireguardDevice.get")
+    def test_show_returns_config(self, mock_get, client):
+        mock_device = MagicMock()
+        mock_config = MagicMock()
+        mock_config.asdict.return_value = {
+            "private_key": "abc",
+            "listen_port": 51820,
+            "peers": [],
+        }
+        mock_device.get_config.return_value = mock_config
+        mock_device.__enter__ = MagicMock(return_value=mock_device)
+        mock_device.__exit__ = MagicMock(return_value=False)
+        mock_device.close = MagicMock()
+        mock_get.return_value = mock_device
+
+        result = client.show("wg0")
+        assert result["listen_port"] == 51820
+
+    @patch("wireguard_tools.daemon.WireguardDevice.get")
+    def test_show_missing_interface(self, mock_get, daemon_socket):
+        resp = _raw_request(daemon_socket, {"cmd": "show", "args": {}})
+        assert resp["ok"] is False
+        mock_get.assert_not_called()
+
+
+class TestSetPeer:
+    @patch("wireguard_tools.daemon.WireguardDevice.get")
+    def test_set_peer_success(self, mock_get, client, example_wgkey):
+        mock_device = MagicMock()
+        mock_config = MagicMock()
+        mock_device.get_config.return_value = mock_config
+        mock_device.close = MagicMock()
+        mock_get.return_value = mock_device
+
+        client.set_peer(
+            "wg0",
+            example_wgkey,
+            allowed_ips=["10.0.0.2/32"],
+            persistent_keepalive=25,
+        )
+
+        mock_config.add_peer.assert_called_once()
+        mock_device.set_config.assert_called_once_with(mock_config)
+
+    def test_set_peer_missing_args(self, daemon_socket):
+        resp = _raw_request(
+            daemon_socket,
+            {"cmd": "set_peer", "args": {"interface": "wg0"}},
+        )
+        assert resp["ok"] is False
+        assert "public_key" in resp["error"].lower()
+
+
+class TestRemovePeer:
+    @patch("wireguard_tools.daemon.WireguardDevice.get")
+    def test_remove_peer_success(self, mock_get, client, example_wgkey):
+        mock_device = MagicMock()
+        mock_config = MagicMock()
+        mock_device.get_config.return_value = mock_config
+        mock_device.close = MagicMock()
+        mock_get.return_value = mock_device
+
+        client.remove_peer("wg0", example_wgkey)
+
+        mock_config.del_peer.assert_called_once()
+        mock_device.set_config.assert_called_once()
+
+
+class TestListDevices:
+    @patch("wireguard_tools.daemon.WireguardDevice.list")
+    def test_list_devices(self, mock_list, client):
+        dev1 = MagicMock()
+        dev1.interface = "wg0"
+        dev2 = MagicMock()
+        dev2.interface = "wg1"
+        mock_list.return_value = iter([dev1, dev2])
+
+        result = client.list_devices()
+        assert result == ["wg0", "wg1"]
+
+
+class TestClientErrorHandling:
+    def test_connection_refused(self):
+        client = WgDaemonClient(socket_path="/tmp/nonexistent-wg-socket.sock")
+        with pytest.raises((ConnectionRefusedError, FileNotFoundError)):
+            client.up("wg0")
+
+    def test_env_var_socket_path(self, daemon_socket):
+        with patch.dict(os.environ, {"WG_DAEMON_SOCKET": daemon_socket}):
+            c = WgDaemonClient()
+            assert c.socket_path == daemon_socket

--- a/tests/test_uapi_protocol.py
+++ b/tests/test_uapi_protocol.py
@@ -1,0 +1,223 @@
+# Tests for UAPI protocol serialization (without real sockets).
+# SPDX-License-Identifier: MIT
+
+from ipaddress import IPv4Address, IPv6Address, ip_interface
+from unittest.mock import MagicMock
+
+import pytest
+
+from wireguard_tools.wireguard_config import WireguardConfig, WireguardPeer
+from wireguard_tools.wireguard_key import WireguardKey
+from wireguard_tools.wireguard_uapi import WireguardUAPIDevice
+
+
+def _make_device() -> WireguardUAPIDevice:
+    """Create a WireguardUAPIDevice with a mocked socket."""
+    dev = object.__new__(WireguardUAPIDevice)
+    dev.interface = "wg-test"
+    dev._buffer = ""
+    dev.uapi_socket = MagicMock()
+    return dev
+
+
+class TestBuildPeerUAPI:
+    def test_basic_peer(self) -> None:
+        dev = _make_device()
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            endpoint_host=IPv4Address("10.0.0.1"),
+            endpoint_port=51820,
+            allowed_ips=[ip_interface("10.0.0.0/24")],
+        )
+        lines = dev._build_peer_uapi(peer)
+        assert any(line.startswith("public_key=") for line in lines)
+        assert "endpoint=10.0.0.1:51820" in lines
+        assert "replace_allowed_ips=true" in lines
+        assert any(line.startswith("allowed_ip=") for line in lines)
+
+    def test_peer_without_endpoint(self) -> None:
+        dev = _make_device()
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            allowed_ips=[ip_interface("10.0.0.0/24")],
+        )
+        lines = dev._build_peer_uapi(peer)
+        assert not any("endpoint=" in line for line in lines)
+
+    def test_peer_with_preshared_key_uses_hex(self) -> None:
+        dev = _make_device()
+        psk = WireguardKey.generate()
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            preshared_key=psk,
+            allowed_ips=[],
+        )
+        lines = dev._build_peer_uapi(peer)
+        psk_lines = [line for line in lines if line.startswith("preshared_key=")]
+        assert len(psk_lines) == 1
+        assert psk_lines[0] == f"preshared_key={psk.hex}"
+        assert "+" not in psk_lines[0]
+        assert "/" not in psk_lines[0]
+        assert "==" not in psk_lines[0]
+
+    def test_peer_with_persistent_keepalive(self) -> None:
+        dev = _make_device()
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            persistent_keepalive=25,
+            allowed_ips=[],
+        )
+        lines = dev._build_peer_uapi(peer)
+        assert "persistent_keepalive_interval=25" in lines
+
+    def test_ipv6_endpoint_uses_brackets(self) -> None:
+        dev = _make_device()
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            endpoint_host=IPv6Address("::1"),
+            endpoint_port=51820,
+            allowed_ips=[],
+        )
+        lines = dev._build_peer_uapi(peer)
+        assert "endpoint=[::1]:51820" in lines
+
+
+class TestSetConfigSerialization:
+    def test_set_config_includes_replace_peers(self) -> None:
+        dev = _make_device()
+        sent_data: list[bytes] = []
+        dev.uapi_socket.sendall = lambda data: sent_data.append(data)
+        dev.uapi_socket.recv = lambda size: b"errno=0\n\n"
+
+        config = WireguardConfig(
+            private_key=WireguardKey.generate(),
+            listen_port=51820,
+        )
+        dev.set_config(config)
+
+        payload = sent_data[0].decode()
+        assert "set=1" in payload
+        assert "replace_peers=true" in payload
+        assert "listen_port=51820" in payload
+
+    def test_set_config_private_key_hex(self) -> None:
+        dev = _make_device()
+        sent_data: list[bytes] = []
+        dev.uapi_socket.sendall = lambda data: sent_data.append(data)
+        dev.uapi_socket.recv = lambda size: b"errno=0\n\n"
+
+        key = WireguardKey.generate()
+        config = WireguardConfig(private_key=key)
+        dev.set_config(config)
+
+        payload = sent_data[0].decode()
+        assert f"private_key={key.hex}" in payload
+
+
+class TestSyncConfigSerialization:
+    def test_sync_removes_absent_peers(self) -> None:
+        dev = _make_device()
+        sent_data: list[bytes] = []
+
+        old_peer_key = WireguardKey.generate()
+        new_peer_key = WireguardKey.generate()
+
+        calls = [0]
+
+        def mock_sendall(data: bytes) -> None:
+            sent_data.append(data)
+
+        def mock_recv(size: int) -> bytes:
+            if calls[0] == 0:
+                calls[0] = 1
+                lines = [
+                    f"public_key={old_peer_key.hex}",
+                    "allowed_ip=10.0.0.1/32",
+                    "errno=0",
+                ]
+                return ("\n".join(lines) + "\n\n").encode()
+            return b"errno=0\n\n"
+
+        dev.uapi_socket.sendall = mock_sendall
+        dev.uapi_socket.recv = mock_recv
+
+        new_config = WireguardConfig()
+        new_config.add_peer(
+            WireguardPeer(
+                public_key=new_peer_key, allowed_ips=[ip_interface("10.0.0.2/32")]
+            )
+        )
+
+        dev.sync_config(new_config)
+
+        sync_payload = sent_data[1].decode()
+        assert f"public_key={old_peer_key.hex}" in sync_payload
+        assert "remove=true" in sync_payload
+        assert f"public_key={new_peer_key.hex}" in sync_payload
+
+
+class TestResolveEndpoint:
+    def test_ipv4_passthrough(self) -> None:
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            endpoint_host=IPv4Address("10.0.0.1"),
+            endpoint_port=51820,
+            allowed_ips=[],
+        )
+        result = WireguardUAPIDevice._resolve_endpoint(peer)
+        assert result == ("10.0.0.1", 51820)
+
+    def test_ipv6_passthrough(self) -> None:
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            endpoint_host=IPv6Address("::1"),
+            endpoint_port=51820,
+            allowed_ips=[],
+        )
+        result = WireguardUAPIDevice._resolve_endpoint(peer)
+        assert result == ("::1", 51820)
+
+    def test_none_returns_none(self) -> None:
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            allowed_ips=[],
+        )
+        assert WireguardUAPIDevice._resolve_endpoint(peer) is None
+
+    def test_hostname_resolution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WG_ENDPOINT_RESOLUTION_RETRIES", "0")
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            endpoint_host="localhost",
+            endpoint_port=51820,
+            allowed_ips=[],
+        )
+        result = WireguardUAPIDevice._resolve_endpoint(peer)
+        assert result is not None
+        assert result[1] == 51820
+
+    def test_unresolvable_hostname_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WG_ENDPOINT_RESOLUTION_RETRIES", "0")
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            endpoint_host="this.host.should.not.exist.invalid",
+            endpoint_port=51820,
+            allowed_ips=[],
+        )
+        with pytest.raises(RuntimeError, match="Unable to resolve"):
+            WireguardUAPIDevice._resolve_endpoint(peer)
+
+    def test_invalid_retries_env_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WG_ENDPOINT_RESOLUTION_RETRIES", "notanumber")
+        peer = WireguardPeer(
+            public_key=WireguardKey.generate(),
+            endpoint_host="localhost",
+            endpoint_port=51820,
+            allowed_ips=[],
+        )
+        result = WireguardUAPIDevice._resolve_endpoint(peer)
+        assert result is not None

--- a/tests/test_wg_quick.py
+++ b/tests/test_wg_quick.py
@@ -1,0 +1,141 @@
+# Tests for the wg_quick module.
+# SPDX-License-Identifier: MIT
+
+from io import StringIO
+from ipaddress import IPv4Network, IPv6Network, ip_interface
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wireguard_tools.wg_quick import (
+    WgQuickError,
+    _collect_allowed_networks,
+    _find_config,
+    _resolve_table,
+)
+from wireguard_tools.wireguard_config import WireguardConfig, WireguardPeer
+from wireguard_tools.wireguard_key import WireguardKey
+
+
+SAMPLE_CONFIG = """\
+[Interface]
+PrivateKey = DnLEmfJzVoCRJYXzdSXIhTqnjygnhh6O+I3ErMS6OUg=
+Address = 10.0.0.2/24
+ListenPort = 51820
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = ba8AwcolBVDuhR/MKFU8O6CZrAjh7c20h6EOnQx0VRE=
+Endpoint = 192.168.1.1:51820
+AllowedIPs = 10.0.0.0/24, 10.1.0.0/16
+PersistentKeepalive = 25
+"""
+
+CATCHALL_CONFIG = """\
+[Interface]
+PrivateKey = DnLEmfJzVoCRJYXzdSXIhTqnjygnhh6O+I3ErMS6OUg=
+Address = 10.0.0.2/24
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = ba8AwcolBVDuhR/MKFU8O6CZrAjh7c20h6EOnQx0VRE=
+Endpoint = 192.168.1.1:51820
+AllowedIPs = 0.0.0.0/0, ::/0
+"""
+
+
+class TestFindConfig:
+    def test_finds_by_conf_path(self, tmp_path: Path) -> None:
+        conf = tmp_path / "wg0.conf"
+        conf.write_text(SAMPLE_CONFIG)
+        ifname, path = _find_config(str(conf))
+        assert ifname == "wg0"
+        assert path == conf
+
+    def test_raises_for_missing(self) -> None:
+        with pytest.raises(WgQuickError, match="not found"):
+            _find_config("nonexistent-interface-xyz")
+
+
+class TestResolveTable:
+    def test_table_off(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(SAMPLE_CONFIG))
+        config.table = "off"
+        assert _resolve_table(config, "wg0") is None
+
+    def test_table_explicit_number(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(SAMPLE_CONFIG))
+        config.table = "42"
+        assert _resolve_table(config, "wg0") == 42
+
+    def test_table_auto_no_catchall(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(SAMPLE_CONFIG))
+        config.table = "auto"
+        assert _resolve_table(config, "wg0") is None
+
+    @patch("wireguard_tools.wg_quick.pyroute2.IPRoute")
+    def test_table_auto_with_catchall(self, mock_iproute: MagicMock) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(CATCHALL_CONFIG))
+        config.table = "auto"
+        mock_ctx = MagicMock()
+        mock_ctx.link_lookup.return_value = [42]
+        mock_iproute.return_value.__enter__ = lambda _: mock_ctx
+        mock_iproute.return_value.__exit__ = lambda *_: None
+        assert _resolve_table(config, "wg0") == 42
+
+
+class TestCollectAllowedNetworks:
+    def test_unique_networks(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(SAMPLE_CONFIG))
+        nets = _collect_allowed_networks(config)
+        assert len(nets) == 2
+        assert IPv4Network("10.0.0.0/24") in nets
+        assert IPv4Network("10.1.0.0/16") in nets
+
+    def test_catchall_networks(self) -> None:
+        config = WireguardConfig.from_wgconfig(StringIO(CATCHALL_CONFIG))
+        nets = _collect_allowed_networks(config)
+        assert IPv4Network("0.0.0.0/0") in nets
+        assert IPv6Network("::/0") in nets
+
+    def test_deduplicates(self) -> None:
+        config = WireguardConfig()
+        key1 = WireguardKey.generate()
+        key2 = WireguardKey.generate()
+        config.add_peer(
+            WireguardPeer(
+                public_key=key1,
+                allowed_ips=[ip_interface("10.0.0.0/24")],
+            )
+        )
+        config.add_peer(
+            WireguardPeer(
+                public_key=key2,
+                allowed_ips=[ip_interface("10.0.0.0/24")],
+            )
+        )
+        nets = _collect_allowed_networks(config)
+        assert len(nets) == 1
+
+
+class TestUpDown:
+    @patch("wireguard_tools.wg_quick._interface_exists", return_value=True)
+    def test_up_fails_if_interface_exists(self, mock_exists: MagicMock, tmp_path: Path) -> None:
+        conf = tmp_path / "wg0.conf"
+        conf.write_text(SAMPLE_CONFIG)
+        with pytest.raises(WgQuickError, match="already exists"):
+            from wireguard_tools.wg_quick import up
+
+            up(str(conf))
+
+    @patch("wireguard_tools.wg_quick._interface_exists", return_value=False)
+    def test_down_fails_if_interface_not_up(
+        self, mock_exists: MagicMock, tmp_path: Path
+    ) -> None:
+        conf = tmp_path / "wg0.conf"
+        conf.write_text(SAMPLE_CONFIG)
+        with pytest.raises(WgQuickError, match="not currently up"):
+            from wireguard_tools.wg_quick import down
+
+            down(str(conf))

--- a/tests/test_wg_quick.py
+++ b/tests/test_wg_quick.py
@@ -4,6 +4,7 @@
 from io import StringIO
 from ipaddress import IPv4Network, IPv6Network, ip_interface
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -139,3 +140,52 @@ class TestUpDown:
             from wireguard_tools.wg_quick import down
 
             down(str(conf))
+
+    @patch("wireguard_tools.wg_quick._setup_dns", return_value=False)
+    @patch("wireguard_tools.wg_quick._collect_allowed_networks", return_value=[])
+    @patch("wireguard_tools.wg_quick._resolve_table", return_value=None)
+    @patch("wireguard_tools.wg_quick._set_link_up")
+    @patch("wireguard_tools.wg_quick._create_interface")
+    @patch("wireguard_tools.wg_quick._interface_exists", return_value=False)
+    def test_up_closes_config_file_handles(
+        self,
+        mock_exists: MagicMock,
+        mock_create_interface: MagicMock,
+        mock_set_link_up: MagicMock,
+        mock_resolve_table: MagicMock,
+        mock_collect_allowed_networks: MagicMock,
+        mock_setup_dns: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        conf = tmp_path / "wg0.conf"
+        conf.write_text(SAMPLE_CONFIG)
+
+        captured_files = []
+        fake_config = SimpleNamespace(
+            preup=[],
+            postup=[],
+            addresses=[],
+            mtu=None,
+            peers={},
+            table="auto",
+            fwmark=None,
+            dns_servers=[],
+            search_domains=[],
+        )
+
+        def fake_from_wgconfig(file_obj):
+            captured_files.append(file_obj)
+            return fake_config
+
+        fake_device = MagicMock()
+        with (
+            patch("wireguard_tools.wg_quick.WireguardConfig.from_wgconfig", side_effect=fake_from_wgconfig),
+            patch("wireguard_tools.wg_quick.WireguardDevice.get", return_value=fake_device),
+        ):
+            from wireguard_tools.wg_quick import up
+
+            up(str(conf))
+
+        assert len(captured_files) == 2
+        assert captured_files[0].closed is True
+        assert captured_files[1].closed is True


### PR DESCRIPTION
## Summary
This PR extends wireguard-tools with several significant enhancements developed while building a WireGuard management GUI. All changes are backward-compatible with the existing API.
### Core library fixes
- **IPv6 endpoint handling**: `_parse_endpoint()` properly handles `[::1]:51820` bracket notation throughout config parsing, UAPI serialization, and wgconfig output
- **Robust comma-list parsing**: `_split_comma_list()` filters empty entries from inputs like `"10.0.0.0/24,"` or `"a,,b"` that previously caused `ValueError` in downstream parsers
- **Hex FwMark support**: `int(value, 0)` for FwMark parsing accepts both `0x1234` and decimal formats
- **Case-insensitive SaveConfig**: `value.lower() == "true"` instead of `value == "true"`
### UAPI backend (`wireguard_uapi.py`)
- **Hostname resolution** with `WG_ENDPOINT_RESOLUTION_RETRIES` support (matching C `wg(8)` behavior)
- **Correct IPv6 endpoint formatting** in UAPI `endpoint=` lines (bracket notation)
- **Hex-encoded preshared keys** in UAPI protocol (was passing base64)
- **Distinct `set_config()` / `sync_config()`**: `set_config` does atomic replace (`replace_peers=true`); `sync_config` diffs against running state and applies only changes (removes absent peers, skips unchanged ones)
- Extracted `_build_peer_uapi()` and `_send_uapi_set()` helpers to reduce duplication
### Netlink backend (`wireguard_netlink.py`)
- Refactored shared logic into `_apply_config()`; both `set_config` and `sync_config` delegate to it
### Device abstraction (`wireguard_device.py`)
- Added abstract `sync_config()` with a default implementation that falls back to `set_config()`
### CLI (`cli.py`) — full `wg(8)` parity
- **`wg set`**: Complex argument parser (`_parse_set_args`) supporting `peer`, `endpoint`, `allowed-ips`, `preshared-key`, `persistent-keepalive`, `remove`, and incremental allowed-ips
- **`wg addconf`** and **`wg syncconf`** subcommands
- **`wg show`** enhancements: `dump` format, per-field filtering, `interfaces` mode, `WG_HIDE_KEYS` support
- **`wg-py up`** / **`wg-py down`** subcommands
### Pure Python `wg-quick` (`wg_quick.py`) — new module
- `up()` and `down()` functions implementing `wg-quick(8)` using `pyroute2` for netlink-based interface, address, route, and fwmark rule management
- DNS setup/teardown via `resolvconf`
- Pre/Post Up/Down hook execution
- `Table = auto|off|<number>` routing logic with catch-all AllowedIPs detection
### Privileged daemon (`daemon.py`, `daemon_client.py`) — new modules
- JSON-over-Unix-socket server (`wg-daemon`) enabling privilege separation: run the daemon as root while clients (e.g., a web GUI) connect unprivileged
- 6 commands: `up`, `down`, `show`, `set_peer`, `remove_peer`, `list_devices`
- `WgDaemonClient` class for easy IPC from any Python consumer
- Systemd service template in `contrib/wg-daemon.service`
### Tests — 67 new tests
- `test_cli_commands.py` (21): `_parse_set_args` and `show` field coverage
- `test_config_parsing.py` (26): endpoint parsing, comma lists, IPv6 roundtrip, FwMark hex, Table/SaveConfig
- `test_uapi_protocol.py` (12): peer UAPI serialization, set/sync config, endpoint resolution
- `test_wg_quick.py` (11): config resolution, table routing, network collection, up/down guards
- `test_daemon.py` (15): full protocol coverage with mocked privileged operations
## Test plan
- [x] All 106 tests pass (`pytest tests/ -v`), 1 pre-existing skip
- [x] Backward-compatible: no changes to existing public API signatures
- [x] No new runtime dependencies beyond existing `pyroute2`, `attrs`, `segno`